### PR TITLE
@me 引数が応答ファイルとして解釈される問題を修正

### DIFF
--- a/RedmineCLI.Tests/ProgramTests.cs
+++ b/RedmineCLI.Tests/ProgramTests.cs
@@ -195,4 +195,35 @@ public class ProgramTests
         // config command might show help and return 0
         result.Should().Be(expectedCode);
     }
+
+    [Fact]
+    public async Task Main_Should_HandleAtSymbol_Without_ResponseFileError()
+    {
+        // Arrange
+        // This test verifies that @me is not interpreted as a response file
+        var args = new[] { "issue", "list", "--assignee", "@me", "--help" };
+
+        // Act
+        var result = await Program.Main(args);
+
+        // Assert
+        // The command should show help (return 0) without trying to interpret @me as a response file
+        // If response file handling was not disabled, this would fail with "Response file 'me' not found"
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Main_Should_AcceptAtMeInAssigneeOption()
+    {
+        // Arrange
+        // Additional test to verify @me works in different contexts
+        var args = new[] { "issue", "create", "--assignee", "@me", "--help" };
+
+        // Act
+        var result = await Program.Main(args);
+
+        // Assert
+        // Should show help without response file error
+        result.Should().Be(0);
+    }
 }

--- a/RedmineCLI/Program.cs
+++ b/RedmineCLI/Program.cs
@@ -109,7 +109,11 @@ public class Program
         });
 
         // Create and use CLI configuration
-        var config = new CommandLineConfiguration(rootCommand);
+        var config = new CommandLineConfiguration(rootCommand)
+        {
+            // Disable response file processing to allow @me syntax
+            ResponseFileTokenReplacer = null
+        };
 
         // Parse and execute
         return await config.InvokeAsync(args);


### PR DESCRIPTION
## 概要
`@me` を引数として使用した際に、System.CommandLineが応答ファイルとして解釈してしまう問題を修正しました。

## 問題
以下のコマンドを実行すると、エラーが発生していました：
```bash
$ redmine issue list -a @me
Response file not found 'me'.
```

## 原因
System.CommandLineのデフォルト動作では、`@`で始まる引数は応答ファイル（コマンドライン引数を記載したファイル）として解釈されます。

## 解決方法
`CommandLineConfiguration`で`ResponseFileTokenReplacer = null`を設定し、応答ファイル処理を無効化しました。

## 変更内容
- `Program.cs`: 応答ファイル処理を無効化
- `ProgramTests.cs`: `@me`引数が正常に処理されることを確認するテストを追加

## テスト計画
- [x] `dotnet test`で全テストがパスすることを確認
- [x] `dotnet run -- issue list -a @me`が正常に動作することを確認
- [x] 引用符なしで`@me`を使用できることを確認