### PR TITLE
feat: Claude Code GitHub Actionsを導入

### DIFF
--- a/.github/workflows/claude-code-action.yml
+++ b/.github/workflows/claude-code-action.yml
@@ -1,0 +1,39 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-code-action:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Action
+        uses: grll/claude-code-action@beta
+        with:
+          use_oauth: true
+          claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
+          claude_refresh_token: ${{ secrets.CLAUDE_REFRESH_TOKEN }}
+          claude_expires_at: ${{ secrets.CLAUDE_EXPIRES_AT }}
+          timeout_minutes: "60"

--- a/.github/workflows/claude-oauth.yml
+++ b/.github/workflows/claude-oauth.yml
@@ -1,0 +1,21 @@
+name: Claude OAuth
+
+on:
+  workflow_dispatch:
+    inputs:
+      code:
+        description: 'Authorization code (leave empty for step 1)'
+        required: false
+
+permissions:
+  actions: write  # Required for cache management
+  contents: read  # Required for basic repository access
+
+jobs:
+  auth:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: grll/claude-code-login@v1
+        with:
+          code: ${{ inputs.code }}
+          secrets_admin_pat: ${{ secrets.SECRETS_ADMIN_PAT }}


### PR DESCRIPTION
## Summary
- Claude Code認証用のOAuthワークフローを追加
- プルリクエストでの自動コードレビュー機能を実装
- `@claude`メンションでClaude Codeを呼び出せるように設定

## Test plan
- [ ] GitHub ActionsでOAuth認証ワークフローが正常に動作することを確認
- [ ] PRで`@claude`メンションした際にClaude Codeが反応することを確認
- [ ] 必要なシークレット（SECRETS_ADMIN_PAT, CLAUDE_ACCESS_TOKEN等）が設定されていることを確認