### PR TITLE
fix: 引数なしで起動時にヘルプを表示

### DIFF
--- a/RedmineCLI/Program.cs
+++ b/RedmineCLI/Program.cs
@@ -105,6 +105,20 @@ public class Program
                 return;
             }
 
+            // Check if no arguments were provided (except debug option)
+            var commandResult = parseResult.CommandResult;
+            var hasSubcommand = commandResult.Children.Any(c => c.Command != rootCommand);
+            var hasDebugOption = parseResult.GetValue(debugOption);
+            
+            // If no subcommand was invoked and no special options (only checking for non-debug options)
+            if (!hasSubcommand && !parseResult.GetValue(licensesOption) && parseResult.Tokens.Count == 0)
+            {
+                // Show help
+                Console.WriteLine(rootCommand.GetHelp(parseResult));
+                Environment.ExitCode = 0;
+                return;
+            }
+
             // Default action - no specific handling needed
         });
 


### PR DESCRIPTION
Fixes #4

## 概要
引数なしでアプリケーションを起動した際に、自動的にヘルプメッセージを表示するように修正しました。

## 変更内容
- `Program.cs`のルートコマンドアクションを修正
- 引数が提供されない場合を検出
- 自動的にヘルプを表示してユーザーエクスペリエンスを向上

## テスト
`redmine`を引数なしで実行すると、利用可能なコマンドとオプションを示すヘルプメニューが表示されることを確認してください。

Generated with [Claude Code](https://claude.ai/code)