### PR TITLE
fix: 引数なしで起動時にヘルプを表示

### DIFF
--- a/RedmineCLI/Program.cs
+++ b/RedmineCLI/Program.cs
@@ -61,6 +61,13 @@ public class Program
         licensesOption.Description = "Show license information";
         rootCommand.Add(licensesOption);
 
+        // Create and use CLI configuration (moved up to be in scope)
+        var config = new CommandLineConfiguration(rootCommand)
+        {
+            // Disable response file processing to allow @me syntax
+            ResponseFileTokenReplacer = null
+        };
+
         // Add root command action to handle global options
         rootCommand.SetAction(async (parseResult) =>
         {
@@ -105,15 +112,20 @@ public class Program
                 return;
             }
 
+            // Show help when no arguments are provided
+            if (parseResult.CommandResult.Command == rootCommand &&
+                parseResult.Tokens.Count == 0 &&
+                !parseResult.GetValue(debugOption))
+            {
+                // Create a new parse result with --help to trigger help display
+                var helpArgs = new[] { "--help" };
+                config.InvokeAsync(helpArgs).Wait();
+                Environment.ExitCode = 0;
+                return;
+            }
+
             // Default action - no specific handling needed
         });
-
-        // Create and use CLI configuration
-        var config = new CommandLineConfiguration(rootCommand)
-        {
-            // Disable response file processing to allow @me syntax
-            ResponseFileTokenReplacer = null
-        };
 
         // Parse and execute
         return await config.InvokeAsync(args);


### PR DESCRIPTION
Fixes #4

## 概要
引数なしでアプリケーションを起動した際に、自動的にヘルプメッセージを表示するように修正しました。

## 変更内容
- `Program.cs`のルートコマンドアクションを修正
- 引数が提供されない場合を検出
- 自動的にヘルプを表示してユーザーエクスペリエンスを向上

## テスト
- dotnet formatでコードフォーマットを適用
- dotnet buildでビルドが成功
- dotnet testで全198件のテストが成功

`redmine`を引数なしで実行すると、利用可能なコマンドとオプションを示すヘルプメニューが表示されることを確認してください。

Generated with [Claude Code](https://claude.ai/code)