### PR TITLE
fix: テストの安定性を改善し、ユニットテストのドキュメントを追加

### DIFF
--- a/RedmineCLI.Tests/Commands/AuthCommandTests.cs
+++ b/RedmineCLI.Tests/Commands/AuthCommandTests.cs
@@ -168,14 +168,14 @@ public class AuthCommandTests
         var result = await _consoleFixture.ExecuteWithTestConsoleAsync(async console =>
         {
             var actualResult = await _authCommand.StatusAsync();
-            
+
             // Verify console output contains expected messages
             var output = console.Output;
             output.Should().Contain("Authentication Status");
             output.Should().Contain("default");
             output.Should().Contain("https://redmine.example.com");
             output.Should().Contain("Connection successful");
-            
+
             return actualResult;
         });
 

--- a/RedmineCLI.Tests/Commands/AuthCommandTests.cs
+++ b/RedmineCLI.Tests/Commands/AuthCommandTests.cs
@@ -10,6 +10,7 @@ using RedmineCLI.ApiClient;
 using RedmineCLI.Commands;
 using RedmineCLI.Models;
 using RedmineCLI.Services;
+using RedmineCLI.Tests.TestInfrastructure;
 
 using Spectre.Console;
 using Spectre.Console.Testing;
@@ -20,13 +21,14 @@ using Profile = RedmineCLI.Models.Profile;
 
 namespace RedmineCLI.Tests.Commands;
 
-[Collection("AuthCommand")]
+[Collection("AnsiConsole")]
 public class AuthCommandTests
 {
     private readonly IConfigService _configService;
     private readonly IRedmineApiClient _apiClient;
     private readonly ILogger<AuthCommand> _logger;
     private readonly AuthCommand _authCommand;
+    private readonly AnsiConsoleTestFixture _consoleFixture;
 
     public AuthCommandTests()
     {
@@ -35,6 +37,7 @@ public class AuthCommandTests
         _logger = Substitute.For<ILogger<AuthCommand>>();
 
         _authCommand = new AuthCommand(_configService, _apiClient, _logger);
+        _consoleFixture = new AnsiConsoleTestFixture();
     }
 
     #region Login Tests
@@ -149,11 +152,6 @@ public class AuthCommandTests
     public async Task Status_Should_ShowConnectionState_When_Authenticated()
     {
         // Arrange
-        var configService = Substitute.For<IConfigService>();
-        var apiClient = Substitute.For<IRedmineApiClient>();
-        var logger = Substitute.For<ILogger<AuthCommand>>();
-        var authCommand = new AuthCommand(configService, apiClient, logger);
-
         var testProfile = new Profile
         {
             Name = "default",
@@ -161,18 +159,30 @@ public class AuthCommandTests
             ApiKey = "test-api-key"
         };
 
-        configService.GetActiveProfileAsync()
+        _configService.GetActiveProfileAsync()
             .Returns(Task.FromResult<Profile?>(testProfile));
-        apiClient.TestConnectionAsync(Arg.Any<CancellationToken>())
+        _apiClient.TestConnectionAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(true));
 
-        // Act
-        var result = await authCommand.StatusAsync();
+        // Act & Assert
+        var result = await _consoleFixture.ExecuteWithTestConsoleAsync(async console =>
+        {
+            var actualResult = await _authCommand.StatusAsync();
+            
+            // Verify console output contains expected messages
+            var output = console.Output;
+            output.Should().Contain("Authentication Status");
+            output.Should().Contain("default");
+            output.Should().Contain("https://redmine.example.com");
+            output.Should().Contain("Connection successful");
+            
+            return actualResult;
+        });
 
         // Assert
         result.Should().Be(0);
-        await configService.Received(1).GetActiveProfileAsync();
-        await apiClient.Received(1).TestConnectionAsync(Arg.Any<CancellationToken>());
+        await _configService.Received(1).GetActiveProfileAsync();
+        await _apiClient.Received(1).TestConnectionAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/RedmineCLI.Tests/Commands/IssueAttachmentCommandTests.cs
+++ b/RedmineCLI.Tests/Commands/IssueAttachmentCommandTests.cs
@@ -116,7 +116,7 @@ public class IssueAttachmentCommandTests
             // Assert console output
             console.Output.Should().Contain("No attachments found for issue #123");
             _tableFormatter.DidNotReceive().FormatAttachments(Arg.Any<List<Attachment>>());
-            
+
             return actualResult;
         });
 
@@ -147,13 +147,13 @@ public class IssueAttachmentCommandTests
         {
             // Simply select with Enter (no selection = empty list)
             console.Input.PushKey(ConsoleKey.Enter);
-            
+
             var actualResult = await _issueCommand.DownloadAttachmentsAsync(issueId, false, null, CancellationToken.None);
 
             // Assert console output
             console.Output.Should().Contain("Select attachments to download");
             console.Output.Should().Contain("No attachments selected");
-            
+
             return actualResult;
         });
 
@@ -192,7 +192,7 @@ public class IssueAttachmentCommandTests
 
             // Assert console output
             console.Output.Should().Contain("Downloaded 3 attachments");
-            
+
             return actualResult;
         });
 
@@ -262,7 +262,7 @@ public class IssueAttachmentCommandTests
             // Assert console output
             console.Output.Should().Contain("No attachments found for issue #123");
             await _apiClient.DidNotReceive().DownloadAttachmentAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
-            
+
             return actualResult;
         });
 
@@ -301,7 +301,7 @@ public class IssueAttachmentCommandTests
             // Assert console output
             console.Output.Should().Contain("report.pdf");
             console.Output.Should().Contain("report_1.pdf");
-            
+
             return actualResult;
         });
 

--- a/RedmineCLI.Tests/Commands/IssueAttachmentCommandTests.cs
+++ b/RedmineCLI.Tests/Commands/IssueAttachmentCommandTests.cs
@@ -14,6 +14,7 @@ using RedmineCLI.Commands;
 using RedmineCLI.Formatters;
 using RedmineCLI.Models;
 using RedmineCLI.Services;
+using RedmineCLI.Tests.TestInfrastructure;
 using RedmineCLI.Utils;
 
 using Spectre.Console;
@@ -32,6 +33,7 @@ public class IssueAttachmentCommandTests
     private readonly IJsonFormatter _jsonFormatter;
     private readonly ILogger<IssueCommand> _logger;
     private readonly IssueCommand _issueCommand;
+    private readonly AnsiConsoleTestFixture _consoleFixture;
 
     public IssueAttachmentCommandTests()
     {
@@ -60,6 +62,7 @@ public class IssueAttachmentCommandTests
         _configService.LoadConfigAsync().Returns(Task.FromResult(config));
 
         _issueCommand = new IssueCommand(_apiClient, _configService, _tableFormatter, _jsonFormatter, _logger);
+        _consoleFixture = new AnsiConsoleTestFixture();
     }
 
     [Fact]
@@ -105,24 +108,20 @@ public class IssueAttachmentCommandTests
 
         _apiClient.GetIssueAsync(issueId, Arg.Any<CancellationToken>()).Returns(Task.FromResult(issue));
 
-        // Act
-        using var console = new TestConsole();
-        console.Profile.Capabilities.Interactive = true;
-        var originalConsole = AnsiConsole.Console;
-        try
+        // Act & Assert
+        var result = await _consoleFixture.ExecuteWithTestConsoleAsync(async console =>
         {
-            AnsiConsole.Console = console;
-            var result = await _issueCommand.ListAttachmentsAsync(issueId, false, CancellationToken.None);
+            var actualResult = await _issueCommand.ListAttachmentsAsync(issueId, false, CancellationToken.None);
 
-            // Assert
-            result.Should().Be(0);
+            // Assert console output
             console.Output.Should().Contain("No attachments found for issue #123");
             _tableFormatter.DidNotReceive().FormatAttachments(Arg.Any<List<Attachment>>());
-        }
-        finally
-        {
-            AnsiConsole.Console = originalConsole;
-        }
+            
+            return actualResult;
+        });
+
+        // Assert
+        result.Should().Be(0);
     }
 
     [Fact]
@@ -143,30 +142,23 @@ public class IssueAttachmentCommandTests
 
         _apiClient.GetIssueAsync(issueId, Arg.Any<CancellationToken>()).Returns(Task.FromResult(issue));
 
-        using var console = new TestConsole();
-        console.Profile.Capabilities.Interactive = true;
-        // Simply select with Enter (no selection = empty list)
-        console.Input.PushKey(ConsoleKey.Enter);
-
-        // Store original console
-        var originalConsole = AnsiConsole.Console;
-        try
+        // Act & Assert
+        var result = await _consoleFixture.ExecuteWithTestConsoleAsync(async console =>
         {
-            AnsiConsole.Console = console;
+            // Simply select with Enter (no selection = empty list)
+            console.Input.PushKey(ConsoleKey.Enter);
+            
+            var actualResult = await _issueCommand.DownloadAttachmentsAsync(issueId, false, null, CancellationToken.None);
 
-            // Act
-            var result = await _issueCommand.DownloadAttachmentsAsync(issueId, false, null, CancellationToken.None);
-
-            // Assert
-            result.Should().Be(0);
+            // Assert console output
             console.Output.Should().Contain("Select attachments to download");
             console.Output.Should().Contain("No attachments selected");
-        }
-        finally
-        {
-            // Restore original console
-            AnsiConsole.Console = originalConsole;
-        }
+            
+            return actualResult;
+        });
+
+        // Assert
+        result.Should().Be(0);
     }
 
     [Fact]
@@ -190,37 +182,30 @@ public class IssueAttachmentCommandTests
         _apiClient.DownloadAttachmentAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(x => new System.IO.MemoryStream(new byte[1024]));
 
-        using var console = new TestConsole();
-        console.Profile.Capabilities.Interactive = true;
-
         // Use temp directory for test
         var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
-        // Store original console
-        var originalConsole = AnsiConsole.Console;
-        try
+        // Act & Assert
+        var result = await _consoleFixture.ExecuteWithTestConsoleAsync(async console =>
         {
-            AnsiConsole.Console = console;
+            var actualResult = await _issueCommand.DownloadAttachmentsAsync(issueId, true, tempDir, CancellationToken.None);
 
-            // Act
-            var result = await _issueCommand.DownloadAttachmentsAsync(issueId, true, tempDir, CancellationToken.None);
-
-            // Assert
-            result.Should().Be(0);
-            await _apiClient.Received(3).DownloadAttachmentAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
-            await _apiClient.Received(1).DownloadAttachmentAsync(1, Arg.Any<CancellationToken>());
-            await _apiClient.Received(1).DownloadAttachmentAsync(2, Arg.Any<CancellationToken>());
-            await _apiClient.Received(1).DownloadAttachmentAsync(3, Arg.Any<CancellationToken>());
+            // Assert console output
             console.Output.Should().Contain("Downloaded 3 attachments");
-        }
-        finally
-        {
-            // Restore original console
-            AnsiConsole.Console = originalConsole;
+            
+            return actualResult;
+        });
 
-            if (Directory.Exists(tempDir))
-                Directory.Delete(tempDir, true);
-        }
+        // Assert
+        result.Should().Be(0);
+        await _apiClient.Received(3).DownloadAttachmentAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _apiClient.Received(1).DownloadAttachmentAsync(1, Arg.Any<CancellationToken>());
+        await _apiClient.Received(1).DownloadAttachmentAsync(2, Arg.Any<CancellationToken>());
+        await _apiClient.Received(1).DownloadAttachmentAsync(3, Arg.Any<CancellationToken>());
+
+        // Cleanup
+        if (Directory.Exists(tempDir))
+            Directory.Delete(tempDir, true);
     }
 
     [Fact]
@@ -269,25 +254,20 @@ public class IssueAttachmentCommandTests
 
         _apiClient.GetIssueAsync(issueId, Arg.Any<CancellationToken>()).Returns(Task.FromResult(issue));
 
-        using var console = new TestConsole();
-        console.Profile.Capabilities.Interactive = true;
-        var originalConsole = AnsiConsole.Console;
-        try
+        // Act & Assert
+        var result = await _consoleFixture.ExecuteWithTestConsoleAsync(async console =>
         {
-            AnsiConsole.Console = console;
+            var actualResult = await _issueCommand.DownloadAttachmentsAsync(issueId, false, null, CancellationToken.None);
 
-            // Act
-            var result = await _issueCommand.DownloadAttachmentsAsync(issueId, false, null, CancellationToken.None);
-
-            // Assert
-            result.Should().Be(0);
+            // Assert console output
             console.Output.Should().Contain("No attachments found for issue #123");
             await _apiClient.DidNotReceive().DownloadAttachmentAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
-        }
-        finally
-        {
-            AnsiConsole.Console = originalConsole;
-        }
+            
+            return actualResult;
+        });
+
+        // Assert
+        result.Should().Be(0);
     }
 
     [Fact]
@@ -310,33 +290,26 @@ public class IssueAttachmentCommandTests
         _apiClient.DownloadAttachmentAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(x => new System.IO.MemoryStream(new byte[1024]));
 
-        using var console = new TestConsole();
-        console.Profile.Capabilities.Interactive = true;
-
         // Use temp directory for test
         var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
-        // Store original console
-        var originalConsole = AnsiConsole.Console;
-        try
+        // Act & Assert
+        var result = await _consoleFixture.ExecuteWithTestConsoleAsync(async console =>
         {
-            AnsiConsole.Console = console;
+            var actualResult = await _issueCommand.DownloadAttachmentsAsync(issueId, true, tempDir, CancellationToken.None);
 
-            // Act
-            var result = await _issueCommand.DownloadAttachmentsAsync(issueId, true, tempDir, CancellationToken.None);
-
-            // Assert
-            result.Should().Be(0);
+            // Assert console output
             console.Output.Should().Contain("report.pdf");
             console.Output.Should().Contain("report_1.pdf");
-        }
-        finally
-        {
-            // Restore original console
-            AnsiConsole.Console = originalConsole;
+            
+            return actualResult;
+        });
 
-            if (Directory.Exists(tempDir))
-                Directory.Delete(tempDir, true);
-        }
+        // Assert
+        result.Should().Be(0);
+
+        // Cleanup
+        if (Directory.Exists(tempDir))
+            Directory.Delete(tempDir, true);
     }
 }

--- a/RedmineCLI.Tests/TestInfrastructure/AnsiConsoleTestFixture.cs
+++ b/RedmineCLI.Tests/TestInfrastructure/AnsiConsoleTestFixture.cs
@@ -1,5 +1,6 @@
 using Spectre.Console;
 using Spectre.Console.Testing;
+
 using Xunit;
 
 namespace RedmineCLI.Tests.TestInfrastructure;
@@ -56,7 +57,7 @@ public class AnsiConsoleTestFixture : IDisposable
         // 非同期操作でもロックを維持するため、SemaphoreSlimを使用
         using var semaphore = new SemaphoreSlim(1, 1);
         await semaphore.WaitAsync();
-        
+
         var testConsole = CreateTestConsole();
         var originalConsole = AnsiConsole.Console;
         try

--- a/RedmineCLI.Tests/TestInfrastructure/AnsiConsoleTestFixture.cs
+++ b/RedmineCLI.Tests/TestInfrastructure/AnsiConsoleTestFixture.cs
@@ -1,0 +1,97 @@
+using Spectre.Console;
+using Spectre.Console.Testing;
+using Xunit;
+
+namespace RedmineCLI.Tests.TestInfrastructure;
+
+/// <summary>
+/// テストにおけるAnsiConsoleの状態管理を行うためのフィクスチャ
+/// </summary>
+public class AnsiConsoleTestFixture : IDisposable
+{
+    private readonly IAnsiConsole _originalConsole;
+    private readonly object _consoleLock = new();
+
+    public AnsiConsoleTestFixture()
+    {
+        _originalConsole = AnsiConsole.Console;
+    }
+
+    /// <summary>
+    /// AnsiConsoleをテスト用のTestConsoleに置き換える
+    /// </summary>
+    public TestConsole CreateTestConsole()
+    {
+        var testConsole = new TestConsole();
+        testConsole.Profile.Capabilities.Interactive = true;
+        return testConsole;
+    }
+
+    /// <summary>
+    /// スレッドセーフなコンソール操作を実行
+    /// </summary>
+    public T ExecuteWithTestConsole<T>(Func<TestConsole, T> action)
+    {
+        lock (_consoleLock)
+        {
+            var testConsole = CreateTestConsole();
+            var originalConsole = AnsiConsole.Console;
+            try
+            {
+                AnsiConsole.Console = testConsole;
+                return action(testConsole);
+            }
+            finally
+            {
+                AnsiConsole.Console = originalConsole;
+            }
+        }
+    }
+
+    /// <summary>
+    /// スレッドセーフなコンソール操作を実行（非同期版）
+    /// </summary>
+    public async Task<T> ExecuteWithTestConsoleAsync<T>(Func<TestConsole, Task<T>> action)
+    {
+        // 非同期操作でもロックを維持するため、SemaphoreSlimを使用
+        using var semaphore = new SemaphoreSlim(1, 1);
+        await semaphore.WaitAsync();
+        
+        var testConsole = CreateTestConsole();
+        var originalConsole = AnsiConsole.Console;
+        try
+        {
+            AnsiConsole.Console = testConsole;
+            return await action(testConsole);
+        }
+        finally
+        {
+            AnsiConsole.Console = originalConsole;
+            semaphore.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        // 元のコンソールを確実に復元
+        AnsiConsole.Console = _originalConsole;
+    }
+}
+
+/// <summary>
+/// AnsiConsoleを使用するテストのコレクション定義
+/// </summary>
+[CollectionDefinition("AnsiConsole")]
+public class AnsiConsoleTestCollection : ICollectionFixture<AnsiConsoleTestFixture>
+{
+    // このクラスは単にコレクションを定義するためのマーカー
+}
+
+/// <summary>
+/// 順次実行が必要なテストのコレクション定義
+/// </summary>
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class SequentialTestCollection
+{
+    // このクラスは単にコレクションを定義するためのマーカー
+}

--- a/RedmineCLI.Tests/xunit.runner.json
+++ b/RedmineCLI.Tests/xunit.runner.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "maxParallelThreads": 1,
+  "parallelizeTestCollections": false,
+  "parallelizeAssembly": false,
+  "diagnosticMessages": true
+}

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -1,0 +1,306 @@
+# RedmineCLI ユニットテストガイド
+
+このドキュメントは、RedmineCLIプロジェクトのユニットテストに関するガイドラインと、テストの安定性を確保するための手順を説明します。
+
+## テスト方針
+
+### t-wada流のテスト手法
+
+このプロジェクトでは、和田卓人（t-wada）氏が推奨するテスト手法に従います。
+
+#### 1. テスト駆動開発（TDD）
+
+**Red → Green → Refactor** のサイクルを徹底します。
+
+```bash
+# 1. Red: 失敗するテストを書く
+dotnet test --filter "NewTestMethodName"
+
+# 2. Green: テストを通す最小限の実装
+dotnet test --filter "NewTestMethodName"
+
+# 3. Refactor: コードを改善
+dotnet test
+```
+
+#### 2. テストのAAAパターン
+
+すべてのテストはArrange-Act-Assertパターンに従います。
+
+```csharp
+[Fact]
+public async Task TestMethod_Should_ExpectedBehavior_When_Condition()
+{
+    // Arrange: テストの準備
+    var service = new RedmineService(mockApiClient.Object);
+    var expectedIssues = new List<Issue> { ... };
+    
+    // Act: テスト対象の実行
+    var result = await service.GetIssuesAsync();
+    
+    // Assert: 結果の検証
+    result.Should().BeEquivalentTo(expectedIssues);
+}
+```
+
+#### 3. テストコードの品質基準
+
+- プロダクションコードと同等の品質を保つ
+- テストの意図が明確になる命名
+- 1テスト1アサーション原則
+- DRY原則の適用（共通処理は基底クラスやヘルパーメソッドへ）
+
+#### 4. テストダブルの使い分け
+
+- **スタブ**: 依存オブジェクトの代替（状態の検証）
+- **モック**: 振る舞いの検証が必要な場合のみ使用
+- できるだけ本物のオブジェクトを使用
+
+#### 5. テストピラミッド
+
+```
+         /\
+        /  \  E2Eテスト（少）
+       /____\
+      /      \  統合テスト（中）
+     /________\
+    /          \  単体テスト（多）
+   /____________\
+```
+
+## テストの実行
+
+### 基本的なテストコマンド
+
+```bash
+# 全テストの実行
+dotnet test
+
+# カバレッジ付きで実行
+dotnet test --collect:"XPlat Code Coverage"
+
+# 特定のテストカテゴリの実行
+dotnet test --filter Category=Unit
+dotnet test --filter FullyQualifiedName~IssueCommandTests
+
+# 単一のテストメソッドの実行
+dotnet test --filter "FullyQualifiedName=RedmineCLI.Tests.Commands.IssueCommandTests.List_Should_ReturnFilteredIssues_When_StatusIsSpecified"
+
+# テストログを詳細に出力
+dotnet test --logger "console;verbosity=detailed"
+```
+
+### テストの並行実行制御
+
+このプロジェクトでは、AnsiConsoleの競合を防ぐため、テストの並行実行を制限しています。
+
+`RedmineCLI.Tests/xunit.runner.json`:
+```json
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "maxParallelThreads": 1,
+  "parallelizeTestCollections": false,
+  "parallelizeAssembly": false,
+  "diagnosticMessages": true
+}
+```
+
+## AnsiConsoleを使用するテスト
+
+### 問題の背景
+
+AnsiConsoleはグローバルな静的インスタンスを使用するため、並行実行されるテストで競合状態が発生する可能性があります。
+
+### 解決策：AnsiConsoleTestFixture
+
+`TestInfrastructure/AnsiConsoleTestFixture.cs`を使用して、AnsiConsoleの状態を適切に管理します。
+
+```csharp
+[Collection("AnsiConsole")]
+public class MyCommandTests
+{
+    private readonly AnsiConsoleTestFixture _consoleFixture;
+
+    public MyCommandTests()
+    {
+        _consoleFixture = new AnsiConsoleTestFixture();
+    }
+
+    [Fact]
+    public async Task MyTest()
+    {
+        // Arrange
+        var command = new MyCommand();
+
+        // Act & Assert
+        var result = await _consoleFixture.ExecuteWithTestConsoleAsync(async console =>
+        {
+            var actualResult = await command.ExecuteAsync();
+            
+            // コンソール出力の検証
+            console.Output.Should().Contain("Expected output");
+            
+            return actualResult;
+        });
+
+        // Assert
+        result.Should().Be(0);
+    }
+}
+```
+
+### テストコレクション
+
+AnsiConsoleを使用するテストクラスには、`[Collection("AnsiConsole")]`属性を付与します。
+
+```csharp
+[Collection("AnsiConsole")]
+public class AuthCommandTests
+{
+    // テストコード
+}
+```
+
+## モックとサブスティテュート
+
+### NSubstituteの使用
+
+このプロジェクトではNSubstituteを使用してモックオブジェクトを作成します。
+
+```csharp
+// インターフェースのモック作成
+var configService = Substitute.For<IConfigService>();
+var apiClient = Substitute.For<IRedmineApiClient>();
+
+// 戻り値の設定
+configService.GetActiveProfileAsync()
+    .Returns(Task.FromResult<Profile?>(testProfile));
+
+// 呼び出しの検証
+await configService.Received(1).SaveConfigAsync(Arg.Any<Config>());
+
+// 特定の条件での検証
+await configService.Received(1).SaveConfigAsync(Arg.Is<Config>(c =>
+    c.Profiles.ContainsKey("default") &&
+    c.Profiles["default"].ApiKey == "test-key"));
+```
+
+## テストの命名規則
+
+### メソッド名
+
+```
+[UnitOfWork]_Should_[ExpectedBehavior]_When_[Condition]
+```
+
+例：
+- `Login_Should_SaveCredentials_When_ValidInput`
+- `Status_Should_ShowConnectionState_When_Authenticated`
+- `Logout_Should_ReturnError_When_NoActiveProfile`
+
+### テストクラス名
+
+```
+[TargetClass]Tests
+```
+
+例：
+- `AuthCommandTests`
+- `ConfigServiceTests`
+- `RedmineApiClientTests`
+
+## テストのデバッグ
+
+### Visual Studio / Visual Studio Code
+
+1. テストエクスプローラーからデバッグ実行
+2. ブレークポイントの設定
+3. デバッグコンソールで変数の確認
+
+### コマンドライン
+
+```bash
+# 特定のテストのみ実行（デバッグしやすい）
+dotnet test --filter "FullyQualifiedName=特定のテスト名" --logger "console;verbosity=detailed"
+
+# テスト結果をファイルに出力
+dotnet test --logger "trx;LogFileName=test_results.trx"
+```
+
+## テスト安定性のチェックリスト
+
+### 新しいテストを追加する前に
+
+- [ ] AnsiConsoleを使用する場合は`AnsiConsoleTestFixture`を使用
+- [ ] 非同期処理は適切にawaitされているか確認
+- [ ] テストデータは他のテストと競合しないか確認
+- [ ] ファイルシステムを使用する場合は一時ディレクトリを使用
+- [ ] テスト後のクリーンアップ処理が実装されているか確認
+
+### テストが不安定な場合
+
+1. **並行実行の問題を確認**
+   ```bash
+   # 10回繰り返して実行
+   for i in {1..10}; do
+     echo "Run $i"
+     dotnet test --filter "特定のテスト名"
+   done
+   ```
+
+2. **グローバル状態の確認**
+   - AnsiConsole.Console
+   - 静的変数
+   - 環境変数
+
+3. **タイミングの問題を確認**
+   - 非同期処理の待機不足
+   - リトライロジックの不足
+
+## 継続的改善
+
+### カバレッジ目標
+
+- 単体テスト: 80%以上
+- 重要なビジネスロジック: 90%以上
+- エラーハンドリング: 100%
+
+### テストの保守
+
+- 定期的にテストの実行時間を確認
+- 不要なテストの削除
+- テストコードのリファクタリング
+- 新しいパターンの文書化
+
+## トラブルシューティング
+
+### よくある問題と解決策
+
+#### 1. "Error: URL cannot be empty" エラー
+
+**原因**: AnsiConsoleが適切に初期化されていない
+
+**解決策**: `AnsiConsoleTestFixture`を使用してテストコンソールを設定
+
+#### 2. テストが時々失敗する
+
+**原因**: 並行実行による競合状態
+
+**解決策**: 
+- `xunit.runner.json`で並行実行を無効化
+- `[Collection("Sequential")]`属性を使用
+
+#### 3. ファイルアクセスエラー
+
+**原因**: 複数のテストが同じファイルにアクセス
+
+**解決策**: 
+- 各テストで一意の一時ファイルを使用
+- `Path.GetTempFileName()`または`Guid.NewGuid()`を使用
+
+## 参考資料
+
+- [xUnit Documentation](https://xunit.net/)
+- [NSubstitute Documentation](https://nsubstitute.github.io/)
+- [FluentAssertions Documentation](https://fluentassertions.com/)
+- [t-wada's Testing Philosophy](https://github.com/t-wada)


### PR DESCRIPTION
## 概要

AnsiConsoleの競合状態によるテストの不安定性を解決し、ユニットテストのガイドラインを文書化しました。

詳細: #37

## 変更内容

- xunit.runner.jsonを追加して並行実行を無効化
- AnsiConsoleTestFixtureを追加してコンソールの状態管理を改善
- AuthCommandTestsとIssueAttachmentCommandTestsを更新
- docs/TEST.mdを作成してt-wada流のテスト方針を文書化

Generated with [Claude Code](https://claude.ai/code)