### PR TITLE
feat: --verboseオプションでユーザーフレンドリーなエラーメッセージを実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ redmine --help
 redmine --version
 redmine --license
 
+# 詳細なエラー情報（スタックトレース）を表示
+redmine --verbose <command>
+
 # AIエージェント向けの使用方法情報を出力
 redmine llms
 ```

--- a/RedmineCLI.Tests/Services/ErrorMessageServiceTests.cs
+++ b/RedmineCLI.Tests/Services/ErrorMessageServiceTests.cs
@@ -1,0 +1,173 @@
+using System.Net;
+using FluentAssertions;
+using RedmineCLI.Exceptions;
+using RedmineCLI.Services;
+using Xunit;
+
+namespace RedmineCLI.Tests.Services;
+
+[Trait("Category", "Unit")]
+public class ErrorMessageServiceTests
+{
+    private readonly ErrorMessageService _service;
+
+    public ErrorMessageServiceTests()
+    {
+        _service = new ErrorMessageService();
+    }
+
+    [Fact]
+    public void GetUserFriendlyMessage_Should_ReturnAuthenticationError_When_RedmineApiExceptionWith401()
+    {
+        // Arrange
+        var exception = new RedmineApiException((int)HttpStatusCode.Unauthorized, "Unauthorized");
+
+        // Act
+        var (message, suggestion) = _service.GetUserFriendlyMessage(exception);
+
+        // Assert
+        message.Should().Be("認証に失敗しました");
+        suggestion.Should().Be("'redmine auth login' を実行して再度認証を行ってください");
+    }
+
+    [Fact]
+    public void GetUserFriendlyMessage_Should_ReturnAccessDeniedError_When_RedmineApiExceptionWith403()
+    {
+        // Arrange
+        var exception = new RedmineApiException((int)HttpStatusCode.Forbidden, "Forbidden");
+
+        // Act
+        var (message, suggestion) = _service.GetUserFriendlyMessage(exception);
+
+        // Assert
+        message.Should().Be("アクセスが拒否されました");
+        suggestion.Should().Be("APIキーの権限を確認してください");
+    }
+
+    [Fact]
+    public void GetUserFriendlyMessage_Should_ReturnProjectNotFoundError_When_RedmineApiExceptionWith404AndProjectInMessage()
+    {
+        // Arrange
+        var exception = new RedmineApiException((int)HttpStatusCode.NotFound, "Project not found");
+
+        // Act
+        var (message, suggestion) = _service.GetUserFriendlyMessage(exception);
+
+        // Assert
+        message.Should().Be("プロジェクトが見つかりません");
+        suggestion.Should().Contain("redmine project list");
+    }
+
+    [Fact]
+    public void GetUserFriendlyMessage_Should_ReturnIssueNotFoundError_When_RedmineApiExceptionWith404AndIssueInMessage()
+    {
+        // Arrange
+        var exception = new RedmineApiException((int)HttpStatusCode.NotFound, "Issue not found");
+
+        // Act
+        var (message, suggestion) = _service.GetUserFriendlyMessage(exception);
+
+        // Assert
+        message.Should().Be("チケットが見つかりません");
+        suggestion.Should().Be("チケットIDを確認してください");
+    }
+
+    [Fact]
+    public void GetUserFriendlyMessage_Should_ReturnRateLimitError_When_RedmineApiExceptionWith429()
+    {
+        // Arrange
+        var exception = new RedmineApiException((int)HttpStatusCode.TooManyRequests, "Too Many Requests");
+
+        // Act
+        var (message, suggestion) = _service.GetUserFriendlyMessage(exception);
+
+        // Assert
+        message.Should().Be("APIのレート制限に達しました");
+        suggestion.Should().Be("しばらく待ってから再度お試しください");
+    }
+
+    [Fact]
+    public void GetUserFriendlyMessage_Should_ReturnNetworkError_When_HttpRequestExceptionWithSocketException()
+    {
+        // Arrange
+        var innerException = new System.Net.Sockets.SocketException();
+        var exception = new HttpRequestException("Connection failed", innerException);
+
+        // Act
+        var (message, suggestion) = _service.GetUserFriendlyMessage(exception);
+
+        // Assert
+        message.Should().Be("サーバーに接続できません");
+        suggestion.Should().Be("ネットワーク接続とRedmineのURLを確認してください");
+    }
+
+    [Fact]
+    public void GetUserFriendlyMessage_Should_ReturnSSLError_When_HttpRequestExceptionWithSSLInMessage()
+    {
+        // Arrange
+        var exception = new HttpRequestException("SSL connection error");
+
+        // Act
+        var (message, suggestion) = _service.GetUserFriendlyMessage(exception);
+
+        // Assert
+        message.Should().Be("SSL/TLS接続エラーが発生しました");
+        suggestion.Should().Be("証明書の設定を確認してください");
+    }
+
+    [Fact]
+    public void GetUserFriendlyMessage_Should_ReturnApiKeyNotSetError_When_InvalidOperationExceptionWithApiKeyInMessage()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("No API key found");
+
+        // Act
+        var (message, suggestion) = _service.GetUserFriendlyMessage(exception);
+
+        // Assert
+        message.Should().Be("APIキーが設定されていません");
+        suggestion.Should().Be("'redmine auth login' を実行して認証を行ってください");
+    }
+
+    [Fact]
+    public void GetUserFriendlyMessage_Should_ReturnNoActiveProfileError_When_InvalidOperationExceptionWithProfileInMessage()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("No active profile configured");
+
+        // Act
+        var (message, suggestion) = _service.GetUserFriendlyMessage(exception);
+
+        // Assert
+        message.Should().Be("アクティブなプロファイルが設定されていません");
+        suggestion.Should().Be("'redmine config set active_profile <profile-name>' を実行してプロファイルを設定してください");
+    }
+
+    [Fact]
+    public void GetUserFriendlyMessage_Should_ReturnTimeoutError_When_TaskCanceledException()
+    {
+        // Arrange
+        var exception = new TaskCanceledException();
+
+        // Act
+        var (message, suggestion) = _service.GetUserFriendlyMessage(exception);
+
+        // Assert
+        message.Should().Be("リクエストがタイムアウトしました");
+        suggestion.Should().Be("ネットワーク接続を確認して、再度お試しください");
+    }
+
+    [Fact]
+    public void GetUserFriendlyMessage_Should_ReturnOriginalMessage_When_UnknownException()
+    {
+        // Arrange
+        var exception = new NotSupportedException("This operation is not supported");
+
+        // Act
+        var (message, suggestion) = _service.GetUserFriendlyMessage(exception);
+
+        // Assert
+        message.Should().Be("This operation is not supported");
+        suggestion.Should().BeNull();
+    }
+}

--- a/RedmineCLI/Services/ErrorMessageService.cs
+++ b/RedmineCLI/Services/ErrorMessageService.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using RedmineCLI.Exceptions;
+
+namespace RedmineCLI.Services;
+
+public interface IErrorMessageService
+{
+    (string message, string? suggestion) GetUserFriendlyMessage(Exception exception);
+}
+
+public class ErrorMessageService : IErrorMessageService
+{
+    public (string message, string? suggestion) GetUserFriendlyMessage(Exception exception)
+    {
+        return exception switch
+        {
+            RedmineApiException apiEx => GetApiErrorMessage(apiEx),
+            HttpRequestException httpEx => GetHttpErrorMessage(httpEx),
+            InvalidOperationException invOpEx when invOpEx.Message.Contains("API key") => 
+                ("APIキーが設定されていません", "'redmine auth login' を実行して認証を行ってください"),
+            InvalidOperationException invOpEx when invOpEx.Message.Contains("No active profile") => 
+                ("アクティブなプロファイルが設定されていません", "'redmine config set active_profile <profile-name>' を実行してプロファイルを設定してください"),
+            ArgumentException argEx when argEx.Message.Contains("Project ID") =>
+                ("無効なプロジェクトIDが指定されました", "'redmine project list' を実行して利用可能なプロジェクトを確認してください"),
+            TaskCanceledException =>
+                ("リクエストがタイムアウトしました", "ネットワーク接続を確認して、再度お試しください"),
+            _ => (exception.Message, null)
+        };
+    }
+
+    private (string message, string? suggestion) GetApiErrorMessage(RedmineApiException exception)
+    {
+        return exception.StatusCode switch
+        {
+            (int)HttpStatusCode.Unauthorized => 
+                ("認証に失敗しました", "'redmine auth login' を実行して再度認証を行ってください"),
+            (int)HttpStatusCode.Forbidden => 
+                ("アクセスが拒否されました", "APIキーの権限を確認してください"),
+            (int)HttpStatusCode.NotFound when exception.Message.Contains("project", StringComparison.OrdinalIgnoreCase) =>
+                ("プロジェクトが見つかりません", $"指定されたプロジェクトは存在しません。\n利用可能なプロジェクトを確認するには 'redmine project list' を実行してください"),
+            (int)HttpStatusCode.NotFound when exception.Message.Contains("issue", StringComparison.OrdinalIgnoreCase) =>
+                ("チケットが見つかりません", "チケットIDを確認してください"),
+            (int)HttpStatusCode.UnprocessableEntity =>
+                ("無効なデータが送信されました", "入力内容を確認してください"),
+            (int)HttpStatusCode.TooManyRequests =>
+                ("APIのレート制限に達しました", "しばらく待ってから再度お試しください"),
+            _ => ($"APIエラー: {exception.Message}", exception.ApiError)
+        };
+    }
+
+    private (string message, string? suggestion) GetHttpErrorMessage(HttpRequestException exception)
+    {
+        if (exception.InnerException is System.Net.Sockets.SocketException)
+        {
+            return ("サーバーに接続できません", "ネットワーク接続とRedmineのURLを確認してください");
+        }
+
+        if (exception.Message.Contains("SSL", StringComparison.OrdinalIgnoreCase) || 
+            exception.Message.Contains("HTTPS", StringComparison.OrdinalIgnoreCase))
+        {
+            return ("SSL/TLS接続エラーが発生しました", "証明書の設定を確認してください");
+        }
+
+        return ("ネットワークエラーが発生しました", "ネットワーク接続を確認してください");
+    }
+}


### PR DESCRIPTION
## 概要

issue #45 の実装。--debugではなく--verboseオプションでユーザーフレンドリーなエラーメッセージを実装しました。

## 変更内容

- ErrorMessageServiceを追加して例外を日本語メッセージに変換
- --verboseオプションを追加してスタックトレースの表示を制御
- グローバル例外ハンドリングを実装
- IssueCommandのエラー処理をグローバルハンドリングに対応
- 単体テストを追加（13テスト）
- README.mdに--verboseオプションのドキュメントを追加

Closes #45

Generated with [Claude Code](https://claude.ai/code)