### PR TITLE
feat: llmsコマンドの出力にすべてのオプションを網羅的に記載

### DIFF
--- a/RedmineCLI.Tests/Commands/LlmsCommandTests.cs
+++ b/RedmineCLI.Tests/Commands/LlmsCommandTests.cs
@@ -25,7 +25,7 @@ public class LlmsCommandTests
     public LlmsCommandTests()
     {
         _logger = Substitute.For<ILogger<LlmsCommand>>();
-        _command = new LlmsCommand(_logger);
+        _command = new LlmsCommand(_logger, null);
         _consoleFixture = new AnsiConsoleTestFixture();
     }
 
@@ -43,7 +43,7 @@ public class LlmsCommandTests
     public void Create_Should_ReturnCommandWithCorrectName()
     {
         // Act
-        var command = LlmsCommand.Create(_logger);
+        var command = LlmsCommand.Create(_logger, null);
 
         // Assert
         command.Name.Should().Be("llms");
@@ -60,7 +60,7 @@ public class LlmsCommandTests
 
             result.Should().Be(0);
             var output = console.Output;
-            output.Should().Contain("# RedmineCLI");
+            output.Should().Contain("# RedmineCLI - Comprehensive Command Reference for LLMs");
             output.Should().Contain("## Installation");
             output.Should().Contain("## Authentication");
             output.Should().Contain("## Core Commands");
@@ -90,7 +90,7 @@ public class LlmsCommandTests
             output.Should().Contain("### Issue Management");
             output.Should().Contain("### Attachment Management");
             output.Should().Contain("### Configuration");
-            output.Should().Contain("## Options");
+            output.Should().Contain("## All Available Options");
             output.Should().Contain("## Features");
             output.Should().Contain("## Configuration Files");
             output.Should().Contain("## API Requirements");
@@ -140,6 +140,65 @@ public class LlmsCommandTests
             output.Should().Contain("Sixel protocol");
             output.Should().Contain("--web");
             output.Should().Contain("--json");
+
+            return result;
+        });
+    }
+
+    [Fact]
+    public async Task ShowLlmsInfoAsync_Should_IncludeAllOptions_When_RootCommandProvided()
+    {
+        // Arrange
+        var rootCommand = new RootCommand("Test root command");
+        var issueCommand = new Command("issue", "Manage issues");
+        var listCommand = new Command("list", "List issues");
+
+        // Add options that were missing in the static output
+        var offsetOption = new Option<int?>("--offset") { Description = "Offset for pagination" };
+        var absoluteTimeOption = new Option<bool>("--absolute-time") { Description = "Display absolute time instead of relative time" };
+
+        listCommand.Add(offsetOption);
+        listCommand.Add(absoluteTimeOption);
+        issueCommand.Add(listCommand);
+        rootCommand.Add(issueCommand);
+
+        var commandWithRoot = new LlmsCommand(_logger, rootCommand);
+
+        // Act & Assert
+        await _consoleFixture.ExecuteWithTestConsoleAsync(async console =>
+        {
+            var result = await commandWithRoot.ShowLlmsInfoAsync(CancellationToken.None);
+            var output = console.Output;
+
+            result.Should().Be(0);
+
+            // Verify that dynamically extracted options are included
+            output.Should().Contain("--offset");
+            output.Should().Contain("Offset for pagination");
+            output.Should().Contain("--absolute-time");
+            output.Should().Contain("Display absolute time instead of relative time");
+            output.Should().Contain("issue list");
+
+            return result;
+        });
+    }
+
+    [Fact]
+    public async Task ShowLlmsInfoAsync_Should_IncludeStaticOptions_When_RootCommandNotProvided()
+    {
+        // Arrange & Act & Assert
+        await _consoleFixture.ExecuteWithTestConsoleAsync(async console =>
+        {
+            var result = await _command.ShowLlmsInfoAsync(CancellationToken.None);
+            var output = console.Output;
+
+            result.Should().Be(0);
+
+            // Verify static fallback includes the missing options
+            output.Should().Contain("--offset");
+            output.Should().Contain("Offset for pagination");
+            output.Should().Contain("--absolute-time");
+            output.Should().Contain("Display absolute time instead of relative time");
 
             return result;
         });

--- a/RedmineCLI/Program.cs
+++ b/RedmineCLI/Program.cs
@@ -46,12 +46,14 @@ public class Program
         var fileSystem = serviceProvider.GetRequiredService<IFileSystem>();
         var attachmentCommand = new AttachmentCommand().CreateCommand(configService, apiClient, tableFormatter, jsonFormatter, fileSystem);
         var llmsLogger = serviceProvider.GetRequiredService<ILogger<LlmsCommand>>();
-        var llmsCommand = LlmsCommand.Create(llmsLogger);
 
         rootCommand.Add(authCommand);
         rootCommand.Add(issueCommand);
         rootCommand.Add(configCommand);
         rootCommand.Add(attachmentCommand);
+
+        // Add llms command after all other commands are added so it can access them
+        var llmsCommand = LlmsCommand.Create(llmsLogger, rootCommand);
         rootCommand.Add(llmsCommand);
 
         // Add global options


### PR DESCRIPTION
Closes #47

## 概要
`redmine llms`コマンドを改善し、LLMがRedmineCLIの全機能を把握できるよう、すべてのコマンドとオプションの詳細情報を動的に抽出して出力するようにしました。

## 変更内容
- `LlmsCommand`をRootCommandから動的にオプション情報を抽出するよう修正
- `--offset`、`--absolute-time`などの全オプションを網羅的に表示
- オプションの説明、型情報、エイリアスを含む詳細情報を出力
- グローバルオプションとコマンド固有オプションを明確に区別
- Native AOT制約に対応（リフレクションを最小限に）
- テストを追加して動的抽出とフォールバック動作を検証

Generated with [Claude Code](https://claude.ai/code)