### PR TITLE
feat: issue list に --sort オプションを追加

### DIFF
--- a/RedmineCLI.Tests/Commands/IssueCommandTests.cs
+++ b/RedmineCLI.Tests/Commands/IssueCommandTests.cs
@@ -84,7 +84,7 @@ public class IssueCommandTests
             .Returns(Task.FromResult(issues));
 
         // Act
-        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, false, false, null, CancellationToken.None);
+        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, false, false, null, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -122,7 +122,7 @@ public class IssueCommandTests
             .Returns(Task.FromResult(issues));
 
         // Act
-        var result = await _issueCommand.ListAsync(null, status, null, null, null, false, false, false, null, CancellationToken.None);
+        var result = await _issueCommand.ListAsync(null, status, null, null, null, false, false, false, null, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -155,7 +155,7 @@ public class IssueCommandTests
             .Returns(Task.FromResult(issues));
 
         // Act
-        var result = await _issueCommand.ListAsync(null, null, null, limit, offset, false, false, false, null, CancellationToken.None);
+        var result = await _issueCommand.ListAsync(null, null, null, limit, offset, false, false, false, null, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -185,7 +185,7 @@ public class IssueCommandTests
             .Returns(Task.FromResult(issues));
 
         // Act
-        var result = await _issueCommand.ListAsync(null, null, null, null, null, true, false, false, null, CancellationToken.None);
+        var result = await _issueCommand.ListAsync(null, null, null, null, null, true, false, false, null, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -216,7 +216,7 @@ public class IssueCommandTests
             .Returns(Task.FromResult(issues));
 
         // Act
-        var result = await _issueCommand.ListAsync(assignee, null, null, null, null, false, false, false, null, CancellationToken.None);
+        var result = await _issueCommand.ListAsync(assignee, null, null, null, null, false, false, false, null, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -246,7 +246,7 @@ public class IssueCommandTests
             .Returns(Task.FromResult(issues));
 
         // Act
-        var result = await _issueCommand.ListAsync(null, null, project, null, null, false, false, false, null, CancellationToken.None);
+        var result = await _issueCommand.ListAsync(null, null, project, null, null, false, false, false, null, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -286,7 +286,7 @@ public class IssueCommandTests
             .Returns(Task.FromResult(issues));
 
         // Act
-        var result = await _issueCommand.ListAsync(assignee, status, project, limit, null, false, false, false, null, CancellationToken.None);
+        var result = await _issueCommand.ListAsync(assignee, status, project, limit, null, false, false, false, null, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -309,7 +309,7 @@ public class IssueCommandTests
 
         // Act & Assert
         await Assert.ThrowsAsync<HttpRequestException>(async () =>
-            await _issueCommand.ListAsync(null, null, null, null, null, false, false, false, null, CancellationToken.None)
+            await _issueCommand.ListAsync(null, null, null, null, null, false, false, false, null, null, CancellationToken.None)
         );
 
         _tableFormatter.DidNotReceive().FormatIssues(Arg.Any<List<Issue>>());
@@ -339,15 +339,15 @@ public class IssueCommandTests
             }
         };
 
-        _apiClient.SearchIssuesAsync(searchQuery, null, null, null, 30, null, Arg.Any<CancellationToken>())
+        _apiClient.SearchIssuesAsync(searchQuery, null, null, null, 30, null, null, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(searchResults));
 
         // Act
-        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, false, false, searchQuery, CancellationToken.None);
+        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, false, false, searchQuery, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
-        await _apiClient.Received(1).SearchIssuesAsync(searchQuery, null, null, null, 30, null, Arg.Any<CancellationToken>());
+        await _apiClient.Received(1).SearchIssuesAsync(searchQuery, null, null, null, 30, null, null, Arg.Any<CancellationToken>());
         _tableFormatter.Received(1).FormatIssues(searchResults);
     }
 
@@ -373,16 +373,16 @@ public class IssueCommandTests
 
         _apiClient.GetCurrentUserAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(currentUser));
-        _apiClient.SearchIssuesAsync(searchQuery, currentUser.Id.ToString(), status, null, 30, null, Arg.Any<CancellationToken>())
+        _apiClient.SearchIssuesAsync(searchQuery, currentUser.Id.ToString(), status, null, 30, null, null, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(searchResults));
 
         // Act
-        var result = await _issueCommand.ListAsync(assignee, status, null, null, null, false, false, false, searchQuery, CancellationToken.None);
+        var result = await _issueCommand.ListAsync(assignee, status, null, null, null, false, false, false, searchQuery, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
         await _apiClient.Received(1).GetCurrentUserAsync(Arg.Any<CancellationToken>());
-        await _apiClient.Received(1).SearchIssuesAsync(searchQuery, currentUser.Id.ToString(), status, null, 30, null, Arg.Any<CancellationToken>());
+        await _apiClient.Received(1).SearchIssuesAsync(searchQuery, currentUser.Id.ToString(), status, null, 30, null, null, Arg.Any<CancellationToken>());
         _tableFormatter.Received(1).FormatIssues(searchResults);
     }
 
@@ -411,15 +411,15 @@ public class IssueCommandTests
             }
         };
 
-        _apiClient.SearchIssuesAsync(searchQuery, null, null, null, 30, null, Arg.Any<CancellationToken>())
+        _apiClient.SearchIssuesAsync(searchQuery, null, null, null, 30, null, null, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(searchResults));
 
         // Act
-        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, false, false, searchQuery, CancellationToken.None);
+        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, false, false, searchQuery, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
-        await _apiClient.Received(1).SearchIssuesAsync(searchQuery, null, null, null, 30, null, Arg.Any<CancellationToken>());
+        await _apiClient.Received(1).SearchIssuesAsync(searchQuery, null, null, null, 30, null, null, Arg.Any<CancellationToken>());
         _tableFormatter.Received(1).FormatIssues(searchResults);
 
         // Verify that the search results include both issue types
@@ -485,7 +485,7 @@ public class IssueCommandTests
             .Returns(Task.FromResult(issues));
 
         // Act
-        var result = await _issueCommand.ListAsync("@me", null, null, null, null, false, false, false, null, CancellationToken.None);
+        var result = await _issueCommand.ListAsync("@me", null, null, null, null, false, false, false, null, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -522,7 +522,7 @@ public class IssueCommandTests
             .Returns(Task.FromResult(issues));
 
         // Act
-        var result = await _issueCommand.ListAsync(null, "all", null, null, null, false, false, false, null, CancellationToken.None);
+        var result = await _issueCommand.ListAsync(null, "all", null, null, null, false, false, false, null, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -540,7 +540,7 @@ public class IssueCommandTests
         _configService.GetActiveProfileAsync().Returns(Task.FromResult<Profile?>(profile));
 
         // Act
-        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, true, false, null, CancellationToken.None);
+        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, true, false, null, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -555,11 +555,111 @@ public class IssueCommandTests
         _configService.GetActiveProfileAsync().Returns(Task.FromResult<Profile?>(null));
 
         // Act
-        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, true, false, null, CancellationToken.None);
+        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, true, false, null, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(1);
         await _configService.Received(1).GetActiveProfileAsync();
+    }
+
+    [Fact]
+    public async Task List_Should_SortBySpecifiedField_When_SortOptionProvided()
+    {
+        // Arrange
+        var issues = new List<Issue>
+        {
+            new Issue { Id = 1, Subject = "Test Issue 1", UpdatedOn = DateTime.Now.AddDays(-1) },
+            new Issue { Id = 2, Subject = "Test Issue 2", UpdatedOn = DateTime.Now }
+        };
+
+        _apiClient.GetIssuesAsync(
+            Arg.Is<IssueFilter>(f => f.Sort == "updated_on:desc"),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(issues));
+
+        // Act
+        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, false, false, null, "updated_on:desc", CancellationToken.None);
+
+        // Assert
+        result.Should().Be(0);
+        await _apiClient.Received(1).GetIssuesAsync(
+            Arg.Is<IssueFilter>(f => f.Sort == "updated_on:desc"),
+            Arg.Any<CancellationToken>());
+        _tableFormatter.Received(1).FormatIssues(issues);
+    }
+
+    [Fact]
+    public async Task List_Should_SortByMultipleFields_When_MultipleSortFieldsProvided()
+    {
+        // Arrange
+        var issues = new List<Issue>
+        {
+            new Issue { Id = 1, Subject = "Test Issue 1", Priority = new Priority { Id = 1, Name = "High" } },
+            new Issue { Id = 2, Subject = "Test Issue 2", Priority = new Priority { Id = 2, Name = "Normal" } }
+        };
+
+        _apiClient.GetIssuesAsync(
+            Arg.Is<IssueFilter>(f => f.Sort == "priority:desc,id"),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(issues));
+
+        // Act
+        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, false, false, null, "priority:desc,id", CancellationToken.None);
+
+        // Assert
+        result.Should().Be(0);
+        await _apiClient.Received(1).GetIssuesAsync(
+            Arg.Is<IssueFilter>(f => f.Sort == "priority:desc,id"),
+            Arg.Any<CancellationToken>());
+        _tableFormatter.Received(1).FormatIssues(issues);
+    }
+
+    [Fact]
+    public async Task List_Should_ReturnError_When_InvalidSortFieldProvided()
+    {
+        // Arrange & Act
+        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, false, false, null, "invalid_field", CancellationToken.None);
+
+        // Assert
+        result.Should().Be(1);
+        await _apiClient.DidNotReceive().GetIssuesAsync(Arg.Any<IssueFilter>(), Arg.Any<CancellationToken>());
+        _tableFormatter.DidNotReceive().FormatIssues(Arg.Any<List<Issue>>());
+    }
+
+    [Fact]
+    public async Task List_Should_ReturnError_When_InvalidSortDirectionProvided()
+    {
+        // Arrange & Act
+        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, false, false, null, "id:invalid", CancellationToken.None);
+
+        // Assert
+        result.Should().Be(1);
+        await _apiClient.DidNotReceive().GetIssuesAsync(Arg.Any<IssueFilter>(), Arg.Any<CancellationToken>());
+        _tableFormatter.DidNotReceive().FormatIssues(Arg.Any<List<Issue>>());
+    }
+
+    [Fact]
+    public async Task List_Should_ApplySortToSearchResults_When_SearchAndSortProvided()
+    {
+        // Arrange
+        var searchQuery = "bug";
+        var sort = "priority:desc";
+        var issues = new List<Issue>
+        {
+            new Issue { Id = 1, Subject = "Bug 1", Priority = new Priority { Id = 1, Name = "High" } },
+            new Issue { Id = 2, Subject = "Bug 2", Priority = new Priority { Id = 2, Name = "Normal" } }
+        };
+
+        _apiClient.SearchIssuesAsync(searchQuery, null, null, null, 30, null, sort, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(issues));
+
+        // Act
+        var result = await _issueCommand.ListAsync(null, null, null, null, null, false, false, false, searchQuery, sort, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(0);
+        await _apiClient.Received(1).SearchIssuesAsync(searchQuery, null, null, null, 30, null, sort, Arg.Any<CancellationToken>());
+        _tableFormatter.Received(1).FormatIssues(issues);
     }
 
     #endregion

--- a/RedmineCLI/ApiClient/IRedmineApiClient.cs
+++ b/RedmineCLI/ApiClient/IRedmineApiClient.cs
@@ -49,5 +49,6 @@ public interface IRedmineApiClient
         string? projectId = null,
         int? limit = null,
         int? offset = null,
+        string? sort = null,
         CancellationToken cancellationToken = default);
 }

--- a/RedmineCLI/ApiClient/RedmineApiClient.cs
+++ b/RedmineCLI/ApiClient/RedmineApiClient.cs
@@ -262,7 +262,8 @@ public class RedmineApiClient : IRedmineApiClient
             ["project_id"] = filter.ProjectId,
             ["status_id"] = filter.StatusId,
             ["limit"] = filter.Limit?.ToString(),
-            ["offset"] = filter.Offset?.ToString()
+            ["offset"] = filter.Offset?.ToString(),
+            ["sort"] = filter.Sort
         });
 
         var path = $"/issues.json{queryString}";
@@ -284,6 +285,7 @@ public class RedmineApiClient : IRedmineApiClient
         string? projectId = null,
         int? limit = null,
         int? offset = null,
+        string? sort = null,
         CancellationToken cancellationToken = default)
     {
         var queryParams = new Dictionary<string, string?>
@@ -319,6 +321,11 @@ public class RedmineApiClient : IRedmineApiClient
         if (!string.IsNullOrEmpty(projectId))
         {
             queryParams["project_id"] = projectId;
+        }
+
+        if (!string.IsNullOrEmpty(sort))
+        {
+            queryParams["sort"] = sort;
         }
 
         var queryString = BuildQueryString(queryParams);

--- a/RedmineCLI/Models/IssueFilter.cs
+++ b/RedmineCLI/Models/IssueFilter.cs
@@ -7,4 +7,5 @@ public class IssueFilter
     public string? StatusId { get; set; }
     public int? Limit { get; set; }
     public int? Offset { get; set; }
+    public string? Sort { get; set; }
 }

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -37,6 +37,11 @@ RedmineCLIは、Redmineのチケット管理をコマンドラインから効率
 14. WHEN `--json` オプションを指定 THEN 日時はISO 8601形式のUTCで出力される SHALL
 15. WHEN `config set time.format` で設定 THEN 指定された形式（relative/absolute/utc）で日時が表示される SHALL
 16. WHEN チケット一覧を表示 THEN 期日（Due Date）が設定されている場合は表示される SHALL
+17. WHEN `--sort <field>` オプションを指定 THEN 指定されたフィールドでチケットがソートされる SHALL
+18. WHEN `--sort <field>:asc` または `--sort <field>:desc` を指定 THEN 指定された方向（昇順/降順）でソートされる SHALL
+19. WHEN `--sort` で複数フィールドを指定（例：`--sort priority:desc,id`） THEN 複数条件でソートされる SHALL
+20. WHEN `--sort` で無効なフィールドを指定 THEN エラーメッセージが表示される SHALL
+21. WHEN `--sort` と他のフィルタオプションを組み合わせる THEN フィルタ後の結果がソートされる SHALL
 
 ### 要求 3
 **ユーザーストーリー:** 開発者として、IDを指定して全情報を表示したいので、チケットの詳細情報を確認できる

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -635,6 +635,28 @@
 - すべてのテスト（250件）が成功
 - 要求12（AIエージェント向け情報出力）の完全実装
 
+### issue list --sort オプション実装（2025-07-25）
+- GitHub issue #57 に基づいて実装
+- TDD手法（Red→Green→Refactor）に従って実装
+- 実装内容：
+  - IssueFilterモデルにSortプロパティを追加
+  - RedmineApiClientのGetIssuesAsyncとSearchIssuesAsyncにsortパラメータを追加
+  - IssueCommandに--sortオプションを追加
+  - ソートパラメータの検証機能（IsValidSortParameter）を実装
+- ソート機能の仕様：
+  - 単一フィールドソート（例：--sort updated_on:desc）
+  - 複数フィールドソート（例：--sort priority:desc,id）
+  - 対応フィールド：id, subject, status, priority, author, assigned_to, updated_on, created_on, start_date, due_date, done_ratio, category, fixed_version
+  - 方向指定：asc（昇順）、desc（降順）、指定なしはデフォルトで昇順
+- テストケース5件を追加：
+  - List_Should_SortBySpecifiedField_When_SortOptionProvided
+  - List_Should_SortByMultipleFields_When_MultipleSortFieldsProvided
+  - List_Should_ReturnError_When_InvalidSortFieldProvided
+  - List_Should_ReturnError_When_InvalidSortDirectionProvided
+  - List_Should_ApplySortToSearchResults_When_SearchAndSortProvided
+- すべてのテスト（291件）が成功
+- 要求2の拡張機能として実装完了
+
 ## 使用方法
 
 ### 実行可能ファイル名


### PR DESCRIPTION
Closes #57

Redmine API の sort パラメータを利用して、チケット一覧をソートできる機能を実装しました。

## 実装内容

- 単一フィールドのソート（例：`--sort updated_on:desc`）
- 複数フィールドのソート（例：`--sort priority:desc,id`）
- 昇順（asc）/降順（desc）の指定をサポート
- 無効なフィールドや方向のバリデーション
- 検索結果（`--search`）でもソート可能

## 対応フィールド

id, subject, status, priority, author, assigned_to, updated_on,
created_on, start_date, due_date, done_ratio, category, fixed_version

## テスト

- ビルド成功
- 全テスト（291件）合格
- コードフォーマット適用済み

Generated with [Claude Code](https://claude.ai/code)