### PR TITLE
fix: プロジェクトフィルタリングでプロジェクト名を識別子に変換するよう修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,16 @@ redmine issue list
 # 特定のステータスでフィルタ
 redmine issue list --status=open
 
+# プロジェクトでフィルタ（プロジェクト名、識別子、IDが使用可能）
+redmine issue list --project "管理"
+redmine issue list -p my-project
+
 # キーワードでチケットを検索
 redmine issue list --search "会議"
 redmine issue list -q "バグ修正"
 
 # 複合検索（検索と他のフィルターの組み合わせ）
-redmine issue list --search "会議" --status open --assignee @me
+redmine issue list --search "会議" --status open --assignee @me --project "開発"
 
 # チケットの詳細を表示
 redmine issue view 12345


### PR DESCRIPTION
## 解決した問題

Fixes #64 

`-p` オプションでプロジェクト名を指定した場合に404エラーが発生する問題を修正しました。

## 変更内容

- `ResolveProjectAsync`メソッドを追加してプロジェクト名を識別子に変換
- プロジェクト名、識別子、IDでのフィルタリングをサポート
- 関連するテストを修正・追加
- README.mdにプロジェクトフィルタリングの使用例を追加

Generated with [Claude Code](https://claude.ai/code)