### PR TITLE
feat: listコマンドにlsエイリアスを追加

### DIFF
--- a/RedmineCLI.Tests/Commands/IssueCommandTests.cs
+++ b/RedmineCLI.Tests/Commands/IssueCommandTests.cs
@@ -49,6 +49,17 @@ public class IssueCommandTests
     #region List Command Tests
 
     [Fact]
+    public void Command_Should_HaveLsAlias()
+    {
+        // Arrange & Act
+        var command = IssueCommand.Create(_apiClient, _configService, _tableFormatter, _jsonFormatter, _logger);
+        var listCommand = command.Subcommands.First(c => c.Name == "list");
+
+        // Assert
+        listCommand.Aliases.Should().Contain("ls");
+    }
+
+    [Fact]
     public async Task List_Should_ReturnAllOpenIssues_When_NoOptionsSpecified()
     {
         // Arrange

--- a/RedmineCLI/Commands/IssueCommand.cs
+++ b/RedmineCLI/Commands/IssueCommand.cs
@@ -50,6 +50,7 @@ public class IssueCommand
         var issueCommand = new IssueCommand(apiClient, configService, tableFormatter, jsonFormatter, logger);
 
         var listCommand = new Command("list", "List issues with optional filters");
+        listCommand.Aliases.Add("ls");
 
         var assigneeOption = new Option<string?>("--assignee") { Description = "Filter by assignee (username, ID, or @me)" };
         assigneeOption.Aliases.Add("-a");

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -21,7 +21,7 @@ RedmineCLIは、Redmineのチケット管理をコマンドラインから効率
 **ユーザーストーリー:** 開発者として、プロジェクト全体のチケット状況を把握し、必要に応じて様々な条件でフィルタリングしたいので、効率的にチケット管理ができる
 
 #### 受け入れ基準
-1. WHEN `redmine issue list` を実行 THEN プロジェクトのオープンなチケット一覧が表示される（デフォルト30件） SHALL
+1. WHEN `redmine issue list` または `redmine issue ls` を実行 THEN プロジェクトのオープンなチケット一覧が表示される（デフォルト30件） SHALL
 2. WHEN `--assignee <user>` または `-a <user>` オプションを指定 THEN 特定のユーザーのチケットが表示される SHALL
 3. WHEN `--assignee @me` または `-a @me` を指定 THEN 現在の認証ユーザーのチケットが表示される SHALL
 4. WHEN `--status <status>` または `-s <status>` オプションを指定 THEN 特定のステータスのチケットが表示される SHALL


### PR DESCRIPTION
## 概要
GitHub CLI (`gh`) のように、`list` コマンドに `ls` というエイリアスを追加しました。

## 変更内容
- `IssueCommand.cs` の `listCommand` に `ls` エイリアスを追加
- エイリアスが正しく動作することを確認するテストを追加
- `docs/REQUIREMENTS.md` を更新して `redmine issue ls` の使用方法を記載

## 動作確認
```bash
# 以下の両方のコマンドが同じ動作をします
redmine issue list
redmine issue ls

# すべてのオプションも同様に使用可能
redmine issue ls --assignee @me
redmine issue ls --status open --project myproject
```

## テスト
- ✅ 新しいテスト `Command_Should_HaveLsAlias` を追加
- ✅ 全テスト (292件) が成功
- ✅ `dotnet format` によるコードフォーマット済み

Closes #67