### PR TITLE
Release v0.8.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,8 @@ jobs:
     needs: create-release
     permissions:
       contents: write
+    env:
+      ASSET_NAME_PREFIX: redmine-cli
     strategy:
       matrix:
         config:
@@ -89,27 +91,22 @@ jobs:
             os: windows-latest
             rid: win-x64
             output: redmine.exe
-            asset_name_prefix: redmine-cli
           - name: "macOS x64"
             os: macos-latest
             rid: osx-x64
             output: redmine
-            asset_name_prefix: redmine-cli
           - name: "macOS ARM64"
             os: macos-latest
             rid: osx-arm64
             output: redmine
-            asset_name_prefix: redmine-cli
           - name: "Linux x64"
             os: ubuntu-latest
             rid: linux-x64
             output: redmine
-            asset_name_prefix: redmine-cli
           - name: "Linux ARM64"
             os: ubuntu-24.04-arm
             rid: linux-arm64
             output: redmine
-            asset_name_prefix: redmine-cli
 
     steps:
     - name: Checkout code
@@ -151,21 +148,21 @@ jobs:
       shell: pwsh
       run: |
         cd publish/${{ matrix.config.rid }}
-        Compress-Archive -Path ${{ matrix.config.output }} -DestinationPath ../../${{ matrix.config.asset_name_prefix }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
+        Compress-Archive -Path ${{ matrix.config.output }} -DestinationPath ../../${{ env.ASSET_NAME_PREFIX }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
         cd ../..
 
     - name: Compress binary to zip (Unix)
       if: runner.os != 'Windows'
       run: |
         cd publish/${{ matrix.config.rid }}
-        zip -j ../../${{ matrix.config.asset_name_prefix }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip ${{ matrix.config.output }}
+        zip -j ../../${{ env.ASSET_NAME_PREFIX }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip ${{ matrix.config.output }}
         cd ../..
 
     - name: Upload Release Assets
       uses: softprops/action-gh-release@v2
       with:
         files: |
-          ${{ matrix.config.asset_name_prefix }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
+          ${{ env.ASSET_NAME_PREFIX }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
 
   generate-checksums:
     name: Generate Checksums

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,27 +89,27 @@ jobs:
             os: windows-latest
             rid: win-x64
             output: redmine.exe
-            asset_name: redmine-cli-win-x64
+            asset_name_prefix: redmine-cli
           - name: "macOS x64"
             os: macos-latest
             rid: osx-x64
             output: redmine
-            asset_name: redmine-cli-osx-x64
+            asset_name_prefix: redmine-cli
           - name: "macOS ARM64"
             os: macos-latest
             rid: osx-arm64
             output: redmine
-            asset_name: redmine-cli-osx-arm64
+            asset_name_prefix: redmine-cli
           - name: "Linux x64"
             os: ubuntu-latest
             rid: linux-x64
             output: redmine
-            asset_name: redmine-cli-linux-x64
+            asset_name_prefix: redmine-cli
           - name: "Linux ARM64"
             os: ubuntu-24.04-arm
             rid: linux-arm64
             output: redmine
-            asset_name: redmine-cli-linux-arm64
+            asset_name_prefix: redmine-cli
 
     steps:
     - name: Checkout code
@@ -151,21 +151,21 @@ jobs:
       shell: pwsh
       run: |
         cd publish/${{ matrix.config.rid }}
-        Compress-Archive -Path ${{ matrix.config.output }} -DestinationPath ../../${{ matrix.config.asset_name }}.zip
+        Compress-Archive -Path ${{ matrix.config.output }} -DestinationPath ../../${{ matrix.config.asset_name_prefix }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
         cd ../..
 
     - name: Compress binary to zip (Unix)
       if: runner.os != 'Windows'
       run: |
         cd publish/${{ matrix.config.rid }}
-        zip -j ../../${{ matrix.config.asset_name }}.zip ${{ matrix.config.output }}
+        zip -j ../../${{ matrix.config.asset_name_prefix }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip ${{ matrix.config.output }}
         cd ../..
 
     - name: Upload Release Assets
       uses: softprops/action-gh-release@v2
       with:
         files: |
-          ${{ matrix.config.asset_name }}.zip
+          ${{ matrix.config.asset_name_prefix }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
 
   generate-checksums:
     name: Generate Checksums
@@ -175,6 +175,13 @@ jobs:
       contents: write
     
     steps:
+    - name: Extract version from tag
+      id: extract_version
+      run: |
+        VERSION=${GITHUB_REF#refs/tags/v}
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Version: $VERSION"
+    
     - name: Download release assets
       uses: robinraju/release-downloader@v1.11
       with:
@@ -185,13 +192,13 @@ jobs:
     - name: Generate checksums
       run: |
         cd downloads
-        sha256sum *.zip > ../checksums.txt
+        sha256sum *.zip > ../redmine-cli-${{ steps.extract_version.outputs.version }}-checksums.txt
         cd ..
-        cat checksums.txt
+        cat redmine-cli-${{ steps.extract_version.outputs.version }}-checksums.txt
     
     - name: Upload checksums
       uses: softprops/action-gh-release@v2
       with:
-        files: checksums.txt
+        files: redmine-cli-${{ steps.extract_version.outputs.version }}-checksums.txt
 
 

--- a/RedmineCLI/RedmineCLI.csproj
+++ b/RedmineCLI/RedmineCLI.csproj
@@ -23,7 +23,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     
     <!-- Versioning -->
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
     <Authors>RedmineCLI Contributors</Authors>
     <Description>A GitHub CLI-like tool for managing Redmine tickets</Description>
   </PropertyGroup>


### PR DESCRIPTION
## 概要
v0.8.1のリリース準備

## 変更内容
- バージョンを0.8.0から0.8.1に更新
- リリースファイル名にバージョン番号を含める形式に変更
  - `redmine-cli-{version}-{platform}-{arch}.zip`
  - `redmine-cli-{version}-checksums.txt`
- `asset_name_prefix`を環境変数として共通化

## リリース手順
1. このPRをマージ
2. mainブランチでタグ`v0.8.1`を作成
3. GitHub Actionsが自動的にリリースを作成

## チェックリスト
- [x] バージョン番号の更新
- [x] リリースワークフローの更新
- [x] テストの実行
- [ ] CHANGELOGの更新（必要に応じて）

## 関連Issue
- #74 - パッケージマネージャー設定の更新