### PR TITLE
feat: 設計書に基づくRedmineServiceの実装

### DIFF
--- a/RedmineCLI.Tests/Services/RedmineServiceTests.cs
+++ b/RedmineCLI.Tests/Services/RedmineServiceTests.cs
@@ -1,0 +1,499 @@
+using System.Globalization;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging;
+
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+using RedmineCLI.ApiClient;
+using RedmineCLI.Exceptions;
+using RedmineCLI.Models;
+using RedmineCLI.Services;
+
+using Xunit;
+
+namespace RedmineCLI.Tests.Services;
+
+public class RedmineServiceTests
+{
+    private readonly IRedmineApiClient _mockApiClient;
+    private readonly ILogger<RedmineService> _mockLogger;
+    private readonly RedmineService _sut;
+
+    public RedmineServiceTests()
+    {
+        _mockApiClient = Substitute.For<IRedmineApiClient>();
+        _mockLogger = Substitute.For<ILogger<RedmineService>>();
+        _sut = new RedmineService(_mockApiClient, _mockLogger);
+    }
+
+    [Fact]
+    public async Task GetIssuesAsync_Should_ReturnIssues_When_Called()
+    {
+        // Arrange
+        var filter = new IssueFilter { StatusId = "open" };
+        var expectedIssues = new List<Issue>
+        {
+            new() { Id = 1, Subject = "Test Issue 1" },
+            new() { Id = 2, Subject = "Test Issue 2" }
+        };
+        _mockApiClient.GetIssuesAsync(filter, Arg.Any<CancellationToken>())
+            .Returns(expectedIssues);
+
+        // Act
+        var result = await _sut.GetIssuesAsync(filter);
+
+        // Assert
+        result.Should().BeEquivalentTo(expectedIssues);
+        await _mockApiClient.Received(1).GetIssuesAsync(filter, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetIssuesAsync_Should_ResolveAtMe_When_AssignedToIsAtMe()
+    {
+        // Arrange
+        var filter = new IssueFilter { AssignedToId = "@me" };
+        var currentUser = new User { Id = 123, Name = "Test User" };
+        var expectedIssues = new List<Issue> { new() { Id = 1, Subject = "My Issue" } };
+
+        _mockApiClient.GetCurrentUserAsync(Arg.Any<CancellationToken>())
+            .Returns(currentUser);
+        _mockApiClient.GetIssuesAsync(
+            Arg.Is<IssueFilter>(f => f.AssignedToId == "123"),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedIssues);
+
+        // Act
+        var result = await _sut.GetIssuesAsync(filter);
+
+        // Assert
+        result.Should().BeEquivalentTo(expectedIssues);
+        await _mockApiClient.Received(1).GetCurrentUserAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateIssueAsync_Should_CreateIssue_When_ValidDataProvided()
+    {
+        // Arrange
+        const string projectIdentifier = "test-project";
+        const string subject = "New Issue";
+        const string description = "Issue description";
+        var projects = new List<Project>
+        {
+            new() { Id = 10, Identifier = projectIdentifier, Name = "Test Project" }
+        };
+        var expectedIssue = new Issue { Id = 100, Subject = subject };
+
+        _mockApiClient.GetProjectsAsync(Arg.Any<CancellationToken>())
+            .Returns(projects);
+        _mockApiClient.CreateIssueAsync(
+            Arg.Is<Issue>(i => i.Subject == subject && i.Project!.Id == 10),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedIssue);
+
+        // Act
+        var result = await _sut.CreateIssueAsync(projectIdentifier, subject, description);
+
+        // Assert
+        result.Should().BeEquivalentTo(expectedIssue);
+        await _mockApiClient.Received(1).CreateIssueAsync(
+            Arg.Is<Issue>(i => i.Subject == subject && i.Description == description),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateIssueAsync_Should_ResolveAtMe_When_AssigneeIsAtMe()
+    {
+        // Arrange
+        const string projectId = "1";
+        const string subject = "New Issue";
+        const string assignee = "@me";
+        var currentUser = new User { Id = 123, Name = "Test User" };
+        var expectedIssue = new Issue { Id = 100, Subject = subject };
+
+        _mockApiClient.GetCurrentUserAsync(Arg.Any<CancellationToken>())
+            .Returns(currentUser);
+        _mockApiClient.CreateIssueAsync(
+            Arg.Is<Issue>(i => i.AssignedTo!.Id == 123),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedIssue);
+
+        // Act
+        var result = await _sut.CreateIssueAsync(projectId, subject, null, assignee);
+
+        // Assert
+        result.Should().BeEquivalentTo(expectedIssue);
+        await _mockApiClient.Received(1).GetCurrentUserAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateIssueAsync_Should_UpdateIssue_When_ValidDataProvided()
+    {
+        // Arrange
+        const int issueId = 1;
+        const string newSubject = "Updated Subject";
+        var existingIssue = new Issue { Id = issueId, Subject = "Original Subject" };
+        var updatedIssue = new Issue { Id = issueId, Subject = newSubject };
+
+        _mockApiClient.GetIssueAsync(issueId, Arg.Any<CancellationToken>())
+            .Returns(existingIssue);
+        _mockApiClient.UpdateIssueAsync(
+            issueId,
+            Arg.Is<Issue>(i => i.Subject == newSubject),
+            Arg.Any<CancellationToken>())
+            .Returns(updatedIssue);
+
+        // Act
+        var result = await _sut.UpdateIssueAsync(issueId, newSubject);
+
+        // Assert
+        result.Should().BeEquivalentTo(updatedIssue);
+        await _mockApiClient.Received(1).UpdateIssueAsync(
+            issueId,
+            Arg.Is<Issue>(i => i.Subject == newSubject),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateIssueAsync_Should_ResolveStatusName_When_StatusNameProvided()
+    {
+        // Arrange
+        const int issueId = 1;
+        const string statusName = "In Progress";
+        var existingIssue = new Issue { Id = issueId, Subject = "Test Issue" };
+        var statuses = new List<IssueStatus>
+        {
+            new() { Id = 1, Name = "New" },
+            new() { Id = 2, Name = "In Progress" },
+            new() { Id = 3, Name = "Closed" }
+        };
+        var updatedIssue = new Issue { Id = issueId, Subject = "Test Issue", Status = statuses[1] };
+
+        _mockApiClient.GetIssueAsync(issueId, Arg.Any<CancellationToken>())
+            .Returns(existingIssue);
+        _mockApiClient.GetIssueStatusesAsync(Arg.Any<CancellationToken>())
+            .Returns(statuses);
+        _mockApiClient.UpdateIssueAsync(
+            issueId,
+            Arg.Is<Issue>(i => i.Status!.Id == 2),
+            Arg.Any<CancellationToken>())
+            .Returns(updatedIssue);
+
+        // Act
+        var result = await _sut.UpdateIssueAsync(issueId, statusIdOrName: statusName);
+
+        // Assert
+        result.Should().BeEquivalentTo(updatedIssue);
+        await _mockApiClient.Received(1).GetIssueStatusesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(101)]
+    public async Task UpdateIssueAsync_Should_ThrowValidationException_When_DoneRatioIsInvalid(int invalidDoneRatio)
+    {
+        // Arrange
+        const int issueId = 1;
+        var existingIssue = new Issue { Id = issueId, Subject = "Test Issue" };
+        _mockApiClient.GetIssueAsync(issueId, Arg.Any<CancellationToken>())
+            .Returns(existingIssue);
+
+        // Act
+        var act = async () => await _sut.UpdateIssueAsync(issueId, doneRatio: invalidDoneRatio);
+
+        // Assert
+        await act.Should().ThrowAsync<ValidationException>()
+            .WithMessage("Progress must be between 0 and 100");
+    }
+
+    [Fact]
+    public async Task ResolveAssigneeAsync_Should_ReturnEmpty_When_AssigneeIsNullOrEmpty()
+    {
+        // Arrange & Act
+        var result1 = await _sut.ResolveAssigneeAsync(null);
+        var result2 = await _sut.ResolveAssigneeAsync(string.Empty);
+
+        // Assert
+        result1.Should().BeEmpty();
+        result2.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveAssigneeAsync_Should_ReturnSameValue_When_AssigneeIsNumeric()
+    {
+        // Arrange
+        const string numericAssignee = "123";
+
+        // Act
+        var result = await _sut.ResolveAssigneeAsync(numericAssignee);
+
+        // Assert
+        result.Should().Be(numericAssignee);
+    }
+
+    [Fact]
+    public async Task ResolveAssigneeAsync_Should_ReturnCurrentUserId_When_AssigneeIsAtMe()
+    {
+        // Arrange
+        var currentUser = new User { Id = 456, Name = "Current User" };
+        _mockApiClient.GetCurrentUserAsync(Arg.Any<CancellationToken>())
+            .Returns(currentUser);
+
+        // Act
+        var result = await _sut.ResolveAssigneeAsync("@me");
+
+        // Assert
+        result.Should().Be("456");
+        await _mockApiClient.Received(1).GetCurrentUserAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResolveStatusIdAsync_Should_ReturnNull_When_StatusIsNullOrEmpty()
+    {
+        // Arrange & Act
+        var result1 = await _sut.ResolveStatusIdAsync(null);
+        var result2 = await _sut.ResolveStatusIdAsync(string.Empty);
+
+        // Assert
+        result1.Should().BeNull();
+        result2.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveStatusIdAsync_Should_ReturnSameValue_When_StatusIsNumeric()
+    {
+        // Arrange
+        const string numericStatus = "5";
+
+        // Act
+        var result = await _sut.ResolveStatusIdAsync(numericStatus);
+
+        // Assert
+        result.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task ResolveStatusIdAsync_Should_ReturnStatusId_When_StatusNameProvided()
+    {
+        // Arrange
+        const string statusName = "closed";
+        var statuses = new List<IssueStatus>
+        {
+            new() { Id = 1, Name = "New" },
+            new() { Id = 2, Name = "In Progress" },
+            new() { Id = 3, Name = "Closed" }
+        };
+        _mockApiClient.GetIssueStatusesAsync(Arg.Any<CancellationToken>())
+            .Returns(statuses);
+
+        // Act
+        var result = await _sut.ResolveStatusIdAsync(statusName);
+
+        // Assert
+        result.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ResolveStatusIdAsync_Should_ThrowValidationException_When_StatusNotFound()
+    {
+        // Arrange
+        const string unknownStatus = "Unknown";
+        var statuses = new List<IssueStatus>
+        {
+            new() { Id = 1, Name = "New" },
+            new() { Id = 2, Name = "In Progress" }
+        };
+        _mockApiClient.GetIssueStatusesAsync(Arg.Any<CancellationToken>())
+            .Returns(statuses);
+
+        // Act
+        var act = async () => await _sut.ResolveStatusIdAsync(unknownStatus);
+
+        // Assert
+        await act.Should().ThrowAsync<ValidationException>()
+            .WithMessage($"Status '{unknownStatus}' not found");
+    }
+
+    [Fact]
+    public async Task ResolveProjectIdAsync_Should_ThrowValidationException_When_ProjectIsNullOrEmpty()
+    {
+        // Arrange & Act
+        var act1 = async () => await _sut.ResolveProjectIdAsync(null!);
+        var act2 = async () => await _sut.ResolveProjectIdAsync(string.Empty);
+
+        // Assert
+        await act1.Should().ThrowAsync<ValidationException>()
+            .WithMessage("Project ID or identifier is required");
+        await act2.Should().ThrowAsync<ValidationException>()
+            .WithMessage("Project ID or identifier is required");
+    }
+
+    [Fact]
+    public async Task ResolveProjectIdAsync_Should_ReturnSameValue_When_ProjectIsNumeric()
+    {
+        // Arrange
+        const string numericProject = "10";
+
+        // Act
+        var result = await _sut.ResolveProjectIdAsync(numericProject);
+
+        // Assert
+        result.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task ResolveProjectIdAsync_Should_ReturnProjectId_When_IdentifierProvided()
+    {
+        // Arrange
+        const string projectIdentifier = "test-proj";
+        var projects = new List<Project>
+        {
+            new() { Id = 1, Identifier = "main-proj", Name = "Main Project" },
+            new() { Id = 2, Identifier = projectIdentifier, Name = "Test Project" }
+        };
+        _mockApiClient.GetProjectsAsync(Arg.Any<CancellationToken>())
+            .Returns(projects);
+
+        // Act
+        var result = await _sut.ResolveProjectIdAsync(projectIdentifier);
+
+        // Assert
+        result.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ResolveProjectIdAsync_Should_ReturnProjectId_When_NameProvided()
+    {
+        // Arrange
+        const string projectName = "Test Project";
+        var projects = new List<Project>
+        {
+            new() { Id = 1, Identifier = "main-proj", Name = "Main Project" },
+            new() { Id = 2, Identifier = "test-proj", Name = projectName }
+        };
+        _mockApiClient.GetProjectsAsync(Arg.Any<CancellationToken>())
+            .Returns(projects);
+
+        // Act
+        var result = await _sut.ResolveProjectIdAsync(projectName);
+
+        // Assert
+        result.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ResolveProjectIdAsync_Should_ThrowValidationException_When_ProjectNotFound()
+    {
+        // Arrange
+        const string unknownProject = "Unknown";
+        var projects = new List<Project>
+        {
+            new() { Id = 1, Identifier = "proj1", Name = "Project 1" }
+        };
+        _mockApiClient.GetProjectsAsync(Arg.Any<CancellationToken>())
+            .Returns(projects);
+
+        // Act
+        var act = async () => await _sut.ResolveProjectIdAsync(unknownProject);
+
+        // Assert
+        await act.Should().ThrowAsync<ValidationException>()
+            .WithMessage($"Project '{unknownProject}' not found");
+    }
+
+    [Fact]
+    public async Task GetCurrentUserAsync_Should_UseCache_When_CacheIsValid()
+    {
+        // Arrange
+        var currentUser = new User { Id = 123, Name = "Test User" };
+        _mockApiClient.GetCurrentUserAsync(Arg.Any<CancellationToken>())
+            .Returns(currentUser);
+
+        // Act
+        var result1 = await _sut.GetCurrentUserAsync();
+        var result2 = await _sut.GetCurrentUserAsync();
+
+        // Assert
+        result1.Should().BeEquivalentTo(currentUser);
+        result2.Should().BeEquivalentTo(currentUser);
+        await _mockApiClient.Received(1).GetCurrentUserAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetIssueStatusesAsync_Should_UseCache_When_CacheIsValid()
+    {
+        // Arrange
+        var statuses = new List<IssueStatus>
+        {
+            new() { Id = 1, Name = "New" },
+            new() { Id = 2, Name = "In Progress" }
+        };
+        _mockApiClient.GetIssueStatusesAsync(Arg.Any<CancellationToken>())
+            .Returns(statuses);
+
+        // Act
+        var result1 = await _sut.GetIssueStatusesAsync();
+        var result2 = await _sut.GetIssueStatusesAsync();
+
+        // Assert
+        result1.Should().BeEquivalentTo(statuses);
+        result2.Should().BeEquivalentTo(statuses);
+        await _mockApiClient.Received(1).GetIssueStatusesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetProjectsAsync_Should_UseCache_When_CacheIsValid()
+    {
+        // Arrange
+        var projects = new List<Project>
+        {
+            new() { Id = 1, Identifier = "proj1", Name = "Project 1" },
+            new() { Id = 2, Identifier = "proj2", Name = "Project 2" }
+        };
+        _mockApiClient.GetProjectsAsync(Arg.Any<CancellationToken>())
+            .Returns(projects);
+
+        // Act
+        var result1 = await _sut.GetProjectsAsync();
+        var result2 = await _sut.GetProjectsAsync();
+
+        // Assert
+        result1.Should().BeEquivalentTo(projects);
+        result2.Should().BeEquivalentTo(projects);
+        await _mockApiClient.Received(1).GetProjectsAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TestConnectionAsync_Should_CallApiClient()
+    {
+        // Arrange
+        _mockApiClient.TestConnectionAsync(Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        var result = await _sut.TestConnectionAsync();
+
+        // Assert
+        result.Should().BeTrue();
+        await _mockApiClient.Received(1).TestConnectionAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TestConnectionAsync_WithCredentials_Should_CallApiClient()
+    {
+        // Arrange
+        const string url = "https://example.com";
+        const string apiKey = "test-key";
+        _mockApiClient.TestConnectionAsync(url, apiKey, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        var result = await _sut.TestConnectionAsync(url, apiKey);
+
+        // Assert
+        result.Should().BeTrue();
+        await _mockApiClient.Received(1).TestConnectionAsync(url, apiKey, Arg.Any<CancellationToken>());
+    }
+}

--- a/RedmineCLI/Program.cs
+++ b/RedmineCLI/Program.cs
@@ -197,6 +197,9 @@ public class Program
         // Redmine API Client
         services.AddScoped<IRedmineApiClient, RedmineApiClient>();
 
+        // Redmine Service
+        services.AddScoped<IRedmineService, RedmineService>();
+
         // Utils
         services.AddSingleton<ITimeHelper, TimeHelper>();
 

--- a/RedmineCLI/Services/IRedmineService.cs
+++ b/RedmineCLI/Services/IRedmineService.cs
@@ -1,0 +1,118 @@
+using RedmineCLI.Models;
+
+namespace RedmineCLI.Services;
+
+/// <summary>
+/// Redmineのビジネスロジックを提供するサービス
+/// </summary>
+public interface IRedmineService
+{
+    /// <summary>
+    /// チケット一覧を取得する
+    /// </summary>
+    Task<List<Issue>> GetIssuesAsync(IssueFilter filter, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// チケットを検索する
+    /// </summary>
+    Task<List<Issue>> SearchIssuesAsync(
+        string searchQuery,
+        string? assignedToId = null,
+        string? statusId = null,
+        string? projectId = null,
+        int? limit = null,
+        int? offset = null,
+        string? sort = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// チケットを取得する
+    /// </summary>
+    Task<Issue> GetIssueAsync(int id, bool includeJournals = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// チケットを作成する
+    /// </summary>
+    Task<Issue> CreateIssueAsync(
+        string projectIdOrIdentifier,
+        string subject,
+        string? description = null,
+        string? assigneeIdOrUsername = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// チケットを更新する
+    /// </summary>
+    Task<Issue> UpdateIssueAsync(
+        int id,
+        string? subject = null,
+        string? statusIdOrName = null,
+        string? assigneeIdOrUsername = null,
+        int? doneRatio = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// チケットにコメントを追加する
+    /// </summary>
+    Task AddCommentAsync(int issueId, string comment, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// @meを現在のユーザーIDに解決する
+    /// </summary>
+    Task<string> ResolveAssigneeAsync(string? assigneeIdOrUsername, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// ステータス名をIDに解決する
+    /// </summary>
+    Task<int?> ResolveStatusIdAsync(string? statusIdOrName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// プロジェクト識別子/名前をIDに解決する
+    /// </summary>
+    Task<int> ResolveProjectIdAsync(string projectIdOrIdentifier, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// プロジェクト一覧を取得する
+    /// </summary>
+    Task<List<Project>> GetProjectsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// ユーザー一覧を取得する
+    /// </summary>
+    Task<List<User>> GetUsersAsync(int? limit = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// ステータス一覧を取得する
+    /// </summary>
+    Task<List<IssueStatus>> GetIssueStatusesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 現在のユーザーを取得する
+    /// </summary>
+    Task<User> GetCurrentUserAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 添付ファイルを取得する
+    /// </summary>
+    Task<Attachment> GetAttachmentAsync(int id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 添付ファイルをダウンロードする
+    /// </summary>
+    Task<Stream> DownloadAttachmentAsync(int id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 添付ファイルをURLからダウンロードする
+    /// </summary>
+    Task<Stream> DownloadAttachmentAsync(string contentUrl, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 接続テストを行う
+    /// </summary>
+    Task<bool> TestConnectionAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定されたURLとAPIキーで接続テストを行う
+    /// </summary>
+    Task<bool> TestConnectionAsync(string url, string apiKey, CancellationToken cancellationToken = default);
+}

--- a/RedmineCLI/Services/RedmineService.cs
+++ b/RedmineCLI/Services/RedmineService.cs
@@ -1,0 +1,362 @@
+using System.Globalization;
+
+using Microsoft.Extensions.Logging;
+
+using RedmineCLI.ApiClient;
+using RedmineCLI.Exceptions;
+using RedmineCLI.Models;
+
+namespace RedmineCLI.Services;
+
+/// <summary>
+/// Redmineのビジネスロジックを提供するサービス
+/// </summary>
+public class RedmineService : IRedmineService
+{
+    private readonly IRedmineApiClient _apiClient;
+    private readonly ILogger<RedmineService> _logger;
+
+    // キャッシュ（メモリ内、短期間のみ保持）
+    private User? _currentUserCache;
+    private DateTime _currentUserCacheTime = DateTime.MinValue;
+    private List<IssueStatus>? _statusesCache;
+    private DateTime _statusesCacheTime = DateTime.MinValue;
+    private List<Project>? _projectsCache;
+    private DateTime _projectsCacheTime = DateTime.MinValue;
+    private readonly TimeSpan _cacheExpiration = TimeSpan.FromMinutes(5);
+
+    public RedmineService(IRedmineApiClient apiClient, ILogger<RedmineService> logger)
+    {
+        _apiClient = apiClient;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<Issue>> GetIssuesAsync(IssueFilter filter, CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Getting issues with filter: {@Filter}", filter);
+
+        // @meの解決
+        if (filter.AssignedToId == "@me")
+        {
+            filter.AssignedToId = await ResolveAssigneeAsync("@me", cancellationToken);
+        }
+
+        return await _apiClient.GetIssuesAsync(filter, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<Issue>> SearchIssuesAsync(
+        string searchQuery,
+        string? assignedToId = null,
+        string? statusId = null,
+        string? projectId = null,
+        int? limit = null,
+        int? offset = null,
+        string? sort = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Searching issues with query: {Query}", searchQuery);
+
+        // @meの解決
+        if (assignedToId == "@me")
+        {
+            assignedToId = await ResolveAssigneeAsync("@me", cancellationToken);
+        }
+
+        return await _apiClient.SearchIssuesAsync(
+            searchQuery, assignedToId, statusId, projectId, limit, offset, sort, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Issue> GetIssueAsync(int id, bool includeJournals = false, CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Getting issue {IssueId}, includeJournals: {IncludeJournals}", id, includeJournals);
+        return await _apiClient.GetIssueAsync(id, includeJournals, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Issue> CreateIssueAsync(
+        string projectIdOrIdentifier,
+        string subject,
+        string? description = null,
+        string? assigneeIdOrUsername = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Creating issue in project {Project}", projectIdOrIdentifier);
+
+        // プロジェクトIDの解決
+        var projectId = await ResolveProjectIdAsync(projectIdOrIdentifier, cancellationToken);
+
+        // 担当者の解決
+        int? assignedToId = null;
+        if (!string.IsNullOrEmpty(assigneeIdOrUsername))
+        {
+            var resolvedAssignee = await ResolveAssigneeAsync(assigneeIdOrUsername, cancellationToken);
+            if (int.TryParse(resolvedAssignee, out var assigneeId))
+            {
+                assignedToId = assigneeId;
+            }
+        }
+
+        var issue = new Issue
+        {
+            Subject = subject,
+            Description = description,
+            Project = new Project { Id = projectId },
+            AssignedTo = assignedToId.HasValue ? new User { Id = assignedToId.Value } : null
+        };
+
+        return await _apiClient.CreateIssueAsync(issue, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Issue> UpdateIssueAsync(
+        int id,
+        string? subject = null,
+        string? statusIdOrName = null,
+        string? assigneeIdOrUsername = null,
+        int? doneRatio = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Updating issue {IssueId}", id);
+
+        // 既存のチケットを取得（subjectが必須のため）
+        var existingIssue = await _apiClient.GetIssueAsync(id, cancellationToken);
+
+        var updateData = new Issue
+        {
+            Id = id,
+            Subject = subject ?? existingIssue.Subject
+        };
+
+        // ステータスの解決
+        if (!string.IsNullOrEmpty(statusIdOrName))
+        {
+            var statusId = await ResolveStatusIdAsync(statusIdOrName, cancellationToken);
+            if (statusId.HasValue)
+            {
+                updateData.Status = new IssueStatus { Id = statusId.Value };
+            }
+        }
+
+        // 担当者の解決
+        if (!string.IsNullOrEmpty(assigneeIdOrUsername))
+        {
+            var resolvedAssignee = await ResolveAssigneeAsync(assigneeIdOrUsername, cancellationToken);
+            if (int.TryParse(resolvedAssignee, out var assigneeId))
+            {
+                updateData.AssignedTo = new User { Id = assigneeId };
+            }
+        }
+
+        // 進捗率
+        if (doneRatio.HasValue)
+        {
+            if (doneRatio.Value < 0 || doneRatio.Value > 100)
+            {
+                throw new ValidationException("Progress must be between 0 and 100");
+            }
+            updateData.DoneRatio = doneRatio.Value;
+        }
+
+        return await _apiClient.UpdateIssueAsync(id, updateData, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task AddCommentAsync(int issueId, string comment, CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Adding comment to issue {IssueId}", issueId);
+        await _apiClient.AddCommentAsync(issueId, comment, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> ResolveAssigneeAsync(string? assigneeIdOrUsername, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(assigneeIdOrUsername))
+        {
+            return string.Empty;
+        }
+
+        // 数値の場合はそのまま返す
+        if (int.TryParse(assigneeIdOrUsername, out _))
+        {
+            return assigneeIdOrUsername;
+        }
+
+        // @meの場合は現在のユーザーIDを返す
+        if (assigneeIdOrUsername == "@me")
+        {
+            var currentUser = await GetCurrentUserAsync(cancellationToken);
+            return currentUser.Id.ToString(CultureInfo.InvariantCulture);
+        }
+
+        // それ以外はユーザー名として扱う（現状はそのまま返す）
+        // 将来的にはユーザー名からIDへの変換を実装
+        return assigneeIdOrUsername;
+    }
+
+    /// <inheritdoc/>
+    public async Task<int?> ResolveStatusIdAsync(string? statusIdOrName, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(statusIdOrName))
+        {
+            return null;
+        }
+
+        // 数値の場合はそのまま返す
+        if (int.TryParse(statusIdOrName, out var statusId))
+        {
+            return statusId;
+        }
+
+        // ステータス一覧から名前で検索
+        var statuses = await GetCachedStatusesAsync(cancellationToken);
+        var status = statuses.FirstOrDefault(s =>
+            s.Name.Equals(statusIdOrName, StringComparison.OrdinalIgnoreCase));
+
+        if (status == null)
+        {
+            throw new ValidationException($"Status '{statusIdOrName}' not found");
+        }
+
+        return status.Id;
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> ResolveProjectIdAsync(string projectIdOrIdentifier, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(projectIdOrIdentifier))
+        {
+            throw new ValidationException("Project ID or identifier is required");
+        }
+
+        // 数値の場合はそのまま返す
+        if (int.TryParse(projectIdOrIdentifier, out var projectId))
+        {
+            return projectId;
+        }
+
+        // プロジェクト一覧から識別子で検索
+        var projects = await GetCachedProjectsAsync(cancellationToken);
+        var project = projects.FirstOrDefault(p =>
+            p.Identifier?.Equals(projectIdOrIdentifier, StringComparison.OrdinalIgnoreCase) == true ||
+            p.Name.Equals(projectIdOrIdentifier, StringComparison.OrdinalIgnoreCase));
+
+        if (project == null)
+        {
+            throw new ValidationException($"Project '{projectIdOrIdentifier}' not found");
+        }
+
+        return project.Id;
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<Project>> GetProjectsAsync(CancellationToken cancellationToken = default)
+    {
+        return await GetCachedProjectsAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<User>> GetUsersAsync(int? limit = null, CancellationToken cancellationToken = default)
+    {
+        return await _apiClient.GetUsersAsync(limit, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<IssueStatus>> GetIssueStatusesAsync(CancellationToken cancellationToken = default)
+    {
+        return await GetCachedStatusesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<User> GetCurrentUserAsync(CancellationToken cancellationToken = default)
+    {
+        // キャッシュが有効な場合は返す
+        if (_currentUserCache != null && DateTime.UtcNow - _currentUserCacheTime < _cacheExpiration)
+        {
+            return _currentUserCache;
+        }
+
+        _logger.LogDebug("Fetching current user from API");
+        var user = await _apiClient.GetCurrentUserAsync(cancellationToken);
+
+        // キャッシュに保存
+        _currentUserCache = user;
+        _currentUserCacheTime = DateTime.UtcNow;
+
+        return user;
+    }
+
+    /// <inheritdoc/>
+    public async Task<Attachment> GetAttachmentAsync(int id, CancellationToken cancellationToken = default)
+    {
+        return await _apiClient.GetAttachmentAsync(id, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Stream> DownloadAttachmentAsync(int id, CancellationToken cancellationToken = default)
+    {
+        return await _apiClient.DownloadAttachmentAsync(id, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Stream> DownloadAttachmentAsync(string contentUrl, CancellationToken cancellationToken = default)
+    {
+        return await _apiClient.DownloadAttachmentAsync(contentUrl, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> TestConnectionAsync(CancellationToken cancellationToken = default)
+    {
+        return await _apiClient.TestConnectionAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> TestConnectionAsync(string url, string apiKey, CancellationToken cancellationToken = default)
+    {
+        return await _apiClient.TestConnectionAsync(url, apiKey, cancellationToken);
+    }
+
+    /// <summary>
+    /// キャッシュされたステータス一覧を取得する
+    /// </summary>
+    private async Task<List<IssueStatus>> GetCachedStatusesAsync(CancellationToken cancellationToken)
+    {
+        // キャッシュが有効な場合は返す
+        if (_statusesCache != null && DateTime.UtcNow - _statusesCacheTime < _cacheExpiration)
+        {
+            return _statusesCache;
+        }
+
+        _logger.LogDebug("Fetching issue statuses from API");
+        var statuses = await _apiClient.GetIssueStatusesAsync(cancellationToken);
+
+        // キャッシュに保存
+        _statusesCache = statuses;
+        _statusesCacheTime = DateTime.UtcNow;
+
+        return statuses;
+    }
+
+    /// <summary>
+    /// キャッシュされたプロジェクト一覧を取得する
+    /// </summary>
+    private async Task<List<Project>> GetCachedProjectsAsync(CancellationToken cancellationToken)
+    {
+        // キャッシュが有効な場合は返す
+        if (_projectsCache != null && DateTime.UtcNow - _projectsCacheTime < _cacheExpiration)
+        {
+            return _projectsCache;
+        }
+
+        _logger.LogDebug("Fetching projects from API");
+        var projects = await _apiClient.GetProjectsAsync(cancellationToken);
+
+        // キャッシュに保存
+        _projectsCache = projects;
+        _projectsCacheTime = DateTime.UtcNow;
+
+        return projects;
+    }
+}


### PR DESCRIPTION
このPull Requestは、Issue #77 の要求に基づいてRedmineServiceを実装します。

## 変更内容

- IRedmineServiceインターフェースの定義
- RedmineServiceクラスの実装（ビジネスロジック層）
  - @meの解決処理
  - ステータス名/プロジェクト名からIDへの変換
  - キャッシュ機能（5分間）
  - エラーハンドリング
- 包括的なユニットテスト（25テストケース）
- DIコンテナへのサービス登録

設計書に記載されていたビジネスロジック層として、コマンドとAPIクライアントの間に位置するRedmineServiceを実装しました。

Closes #77

Generated with [Claude Code](https://claude.ai/code)