### PR TITLE
fix: System.CommandLineの日本語エラーメッセージの余分なピリオドを修正

### DIFF
--- a/RedmineCLI/Program.cs
+++ b/RedmineCLI/Program.cs
@@ -86,6 +86,11 @@ public class Program
         // Get error message service
         var errorMessageService = serviceProvider.GetRequiredService<IErrorMessageService>();
 
+        // Create custom TextWriter to intercept and fix error messages
+        var originalError = Console.Error;
+        var errorInterceptor = new ErrorMessageInterceptor(originalError);
+        Console.SetError(errorInterceptor);
+
         // Create and use CLI configuration
         var config = new CommandLineConfiguration(rootCommand)
         {

--- a/RedmineCLI/Utils/ErrorMessageInterceptor.cs
+++ b/RedmineCLI/Utils/ErrorMessageInterceptor.cs
@@ -1,0 +1,88 @@
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace RedmineCLI.Utils;
+
+/// <summary>
+/// Intercepts error messages to fix formatting issues with System.CommandLine
+/// </summary>
+public class ErrorMessageInterceptor : TextWriter
+{
+    private readonly TextWriter _originalWriter;
+    private readonly StringBuilder _buffer = new();
+    private static readonly Regex DoublePeriodPattern = new(@"[。。]\.(?=\s|$)", RegexOptions.Compiled);
+
+    public ErrorMessageInterceptor(TextWriter originalWriter)
+    {
+        _originalWriter = originalWriter;
+    }
+
+    public override Encoding Encoding => _originalWriter.Encoding;
+
+    public override void Write(char value)
+    {
+        _buffer.Append(value);
+        if (value == '\n')
+        {
+            FlushBuffer();
+        }
+    }
+
+    public override void Write(string? value)
+    {
+        if (value == null) return;
+
+        _buffer.Append(value);
+        if (value.Contains('\n'))
+        {
+            FlushBuffer();
+        }
+    }
+
+    public override void WriteLine(string? value)
+    {
+        if (value != null)
+        {
+            _buffer.Append(value);
+        }
+        _buffer.AppendLine();
+        FlushBuffer();
+    }
+
+    public override void WriteLine()
+    {
+        _buffer.AppendLine();
+        FlushBuffer();
+    }
+
+    private void FlushBuffer()
+    {
+        if (_buffer.Length == 0) return;
+
+        var content = _buffer.ToString();
+        _buffer.Clear();
+
+        // Fix double period issue: remove period after Japanese period (。)
+        content = DoublePeriodPattern.Replace(content, "");
+
+        _originalWriter.Write(content);
+    }
+
+    public override void Flush()
+    {
+        FlushBuffer();
+        _originalWriter.Flush();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            FlushBuffer();
+            // Restore original error writer
+            Console.SetError(_originalWriter);
+        }
+        base.Dispose(disposing);
+    }
+}


### PR DESCRIPTION
## Summary
System.CommandLineが日本語のエラーメッセージ末尾に自動的にピリオドを追加する問題を修正しました。

ErrorMessageInterceptorクラスを作成し、コンソールエラー出力をインターセプトして、日本語の句点（。）の後に続くピリオド（.）を削除します。

Fixes #94

## Test plan
✅ 日本語ロケールでエラーメッセージが正しく表示されることを確認
✅ 英語ロケールでエラーメッセージが正常に表示されることを確認

Generated with [Claude Code](https://claude.ai/code)