### PR TITLE
feat: issue editコマンドに説明欄を更新する機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,20 @@ redmine issue create
 
 # チケットを更新
 redmine issue edit 12345 --status=closed
+
+# チケットの説明を更新
+redmine issue edit 12345 --body "新しい説明文"
+redmine issue edit 12345 -b "新しい説明文"
+
+# ファイルから説明を読み込んで更新
+redmine issue edit 12345 --body-file description.md
+redmine issue edit 12345 -F description.md
+
+# 標準入力から説明を読み込んで更新
+echo "新しい説明文" | redmine issue edit 12345 -F -
+
+# 複数のフィールドを同時に更新
+redmine issue edit 12345 --status=resolved --assignee=@me --body "問題を解決しました"
 ```
 
 ### 優先度管理

--- a/RedmineCLI.Tests/Commands/IssueCloseCommandTests.cs
+++ b/RedmineCLI.Tests/Commands/IssueCloseCommandTests.cs
@@ -74,7 +74,7 @@ public class IssueCloseCommandTests
             .Returns(Task.FromResult(statuses));
         _redmineService.GetIssueAsync(123, false, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(currentIssue));
-        _redmineService.UpdateIssueAsync(123, null, "5", null, 100, Arg.Any<CancellationToken>())
+        _redmineService.UpdateIssueAsync(123, null, "5", null, null, 100, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
         // Act
@@ -82,7 +82,7 @@ public class IssueCloseCommandTests
 
         // Assert
         result.Should().Be(0);
-        await _redmineService.Received(1).UpdateIssueAsync(123, null, "5", null, 100, Arg.Any<CancellationToken>());
+        await _redmineService.Received(1).UpdateIssueAsync(123, null, "5", null, null, 100, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -114,7 +114,7 @@ public class IssueCloseCommandTests
             .Returns(Task.FromResult(statuses));
         _redmineService.GetIssueAsync(123, false, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(currentIssue));
-        _redmineService.UpdateIssueAsync(123, null, "6", null, 100, Arg.Any<CancellationToken>())
+        _redmineService.UpdateIssueAsync(123, null, "6", null, null, 100, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
         // Act
@@ -122,7 +122,7 @@ public class IssueCloseCommandTests
 
         // Assert
         result.Should().Be(0);
-        await _redmineService.Received(1).UpdateIssueAsync(123, null, "6", null, 100, Arg.Any<CancellationToken>());
+        await _redmineService.Received(1).UpdateIssueAsync(123, null, "6", null, null, 100, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -153,7 +153,7 @@ public class IssueCloseCommandTests
             .Returns(Task.FromResult(statuses));
         _redmineService.GetIssueAsync(123, false, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(currentIssue));
-        _redmineService.UpdateIssueAsync(123, null, "5", null, 100, Arg.Any<CancellationToken>())
+        _redmineService.UpdateIssueAsync(123, null, "5", null, null, 100, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
         // Act
@@ -192,7 +192,7 @@ public class IssueCloseCommandTests
             .Returns(Task.FromResult(statuses));
         _redmineService.GetIssueAsync(123, false, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(currentIssue));
-        _redmineService.UpdateIssueAsync(123, null, "5", null, doneRatio, Arg.Any<CancellationToken>())
+        _redmineService.UpdateIssueAsync(123, null, "5", null, null, doneRatio, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
         // Act
@@ -200,7 +200,7 @@ public class IssueCloseCommandTests
 
         // Assert
         result.Should().Be(0);
-        await _redmineService.Received(1).UpdateIssueAsync(123, null, "5", null, doneRatio, Arg.Any<CancellationToken>());
+        await _redmineService.Received(1).UpdateIssueAsync(123, null, "5", null, null, doneRatio, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -230,7 +230,7 @@ public class IssueCloseCommandTests
             .Returns(Task.FromResult(statuses));
         _redmineService.GetIssueAsync(123, false, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(currentIssue));
-        _redmineService.UpdateIssueAsync(123, null, "5", null, 100, Arg.Any<CancellationToken>())
+        _redmineService.UpdateIssueAsync(123, null, "5", null, null, 100, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
         // Act
@@ -238,7 +238,7 @@ public class IssueCloseCommandTests
 
         // Assert
         result.Should().Be(0);
-        await _redmineService.Received(1).UpdateIssueAsync(123, null, "5", null, 100, Arg.Any<CancellationToken>());
+        await _redmineService.Received(1).UpdateIssueAsync(123, null, "5", null, null, 100, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -267,7 +267,7 @@ public class IssueCloseCommandTests
 
         // Assert
         result.Should().Be(0);
-        await _redmineService.DidNotReceive().UpdateIssueAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
+        await _redmineService.DidNotReceive().UpdateIssueAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -298,7 +298,7 @@ public class IssueCloseCommandTests
             .Returns(Task.FromResult(statuses));
         _redmineService.GetIssueAsync(123, false, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(currentIssue));
-        _redmineService.UpdateIssueAsync(123, null, "2", null, 100, Arg.Any<CancellationToken>())
+        _redmineService.UpdateIssueAsync(123, null, "2", null, null, 100, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
         // Act
@@ -306,7 +306,7 @@ public class IssueCloseCommandTests
 
         // Assert
         result.Should().Be(0);
-        await _redmineService.Received(1).UpdateIssueAsync(123, null, "2", null, 100, Arg.Any<CancellationToken>());
+        await _redmineService.Received(1).UpdateIssueAsync(123, null, "2", null, null, 100, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -342,7 +342,7 @@ public class IssueCloseCommandTests
 
             _redmineService.GetIssueAsync(id, false, Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult(issue));
-            _redmineService.UpdateIssueAsync(id, null, "5", null, 100, Arg.Any<CancellationToken>())
+            _redmineService.UpdateIssueAsync(id, null, "5", null, null, 100, Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult(updatedIssue));
         }
 
@@ -351,7 +351,7 @@ public class IssueCloseCommandTests
 
         // Assert
         result.Should().Be(0);
-        await _redmineService.Received(3).UpdateIssueAsync(Arg.Any<int>(), null, "5", null, 100, Arg.Any<CancellationToken>());
+        await _redmineService.Received(3).UpdateIssueAsync(Arg.Any<int>(), null, "5", null, null, 100, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -373,7 +373,7 @@ public class IssueCloseCommandTests
 
         // Assert
         result.Should().Be(1);
-        await _redmineService.DidNotReceive().UpdateIssueAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
+        await _redmineService.DidNotReceive().UpdateIssueAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -405,7 +405,7 @@ public class IssueCloseCommandTests
             .Returns(Task.FromResult(issue123));
         _redmineService.GetIssueAsync(999, false, Arg.Any<CancellationToken>())
             .Returns<Issue>(x => throw new RedmineApiException(404, "Not found"));
-        _redmineService.UpdateIssueAsync(123, null, "5", null, 100, Arg.Any<CancellationToken>())
+        _redmineService.UpdateIssueAsync(123, null, "5", null, null, 100, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue123));
 
         // Act
@@ -413,7 +413,7 @@ public class IssueCloseCommandTests
 
         // Assert
         result.Should().Be(1); // Error due to issue 999 not found
-        await _redmineService.Received(1).UpdateIssueAsync(123, null, "5", null, 100, Arg.Any<CancellationToken>());
+        await _redmineService.Received(1).UpdateIssueAsync(123, null, "5", null, null, 100, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -471,7 +471,7 @@ public class IssueCloseCommandTests
             .Returns(Task.FromResult(statuses));
         _redmineService.GetIssueAsync(123, false, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(currentIssue));
-        _redmineService.UpdateIssueAsync(123, null, "5", null, 100, Arg.Any<CancellationToken>())
+        _redmineService.UpdateIssueAsync(123, null, "5", null, null, 100, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
         // Act

--- a/RedmineCLI.Tests/Commands/IssueEditCommandTests.cs
+++ b/RedmineCLI.Tests/Commands/IssueEditCommandTests.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.IO;
 
 using FluentAssertions;
 
@@ -74,6 +75,7 @@ public class IssueEditCommandTests
             "in-progress",
             null,
             null,
+            null,
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
@@ -88,6 +90,7 @@ public class IssueEditCommandTests
             issueId,
             null,
             "in-progress",
+            null,
             null,
             null,
             Arg.Any<CancellationToken>());
@@ -129,6 +132,7 @@ public class IssueEditCommandTests
             null,
             newAssignee,
             null,
+            null,
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
@@ -144,6 +148,7 @@ public class IssueEditCommandTests
             null,
             null,
             newAssignee,
+            null,
             null,
             Arg.Any<CancellationToken>());
     }
@@ -177,6 +182,7 @@ public class IssueEditCommandTests
             null,
             null,
             null,
+            null,
             doneRatio,
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
@@ -189,6 +195,7 @@ public class IssueEditCommandTests
         await _redmineService.Received(1).GetIssueAsync(issueId, false, Arg.Any<CancellationToken>());
         await _redmineService.Received(1).UpdateIssueAsync(
             issueId,
+            null,
             null,
             null,
             null,
@@ -235,6 +242,7 @@ public class IssueEditCommandTests
             newStatus,
             null,
             null,
+            null,
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
@@ -262,7 +270,7 @@ public class IssueEditCommandTests
         // Assert
         result.Should().Be(0);
         await _configService.Received(1).GetActiveProfileAsync();
-        await _redmineService.DidNotReceive().UpdateIssueAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
+        await _redmineService.DidNotReceive().UpdateIssueAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -296,6 +304,7 @@ public class IssueEditCommandTests
             null,
             "@me",
             null,
+            null,
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
@@ -311,6 +320,7 @@ public class IssueEditCommandTests
             null,
             null,
             "@me",
+            null,
             null,
             Arg.Any<CancellationToken>());
     }
@@ -362,6 +372,7 @@ public class IssueEditCommandTests
             null,
             newStatus,
             newAssignee,
+            null,
             doneRatio,
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
@@ -378,6 +389,7 @@ public class IssueEditCommandTests
             null,
             newStatus,
             newAssignee,
+            null,
             doneRatio,
             Arg.Any<CancellationToken>());
     }
@@ -405,7 +417,7 @@ public class IssueEditCommandTests
             .Returns(Task.FromResult(currentIssue));
         _redmineService.GetIssueStatusesAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(statusList));
-        _redmineService.UpdateIssueAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+        _redmineService.UpdateIssueAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<Issue>(new RedmineApiException(404, "Issue not found")));
 
         // Act
@@ -414,7 +426,7 @@ public class IssueEditCommandTests
         // Assert
         result.Should().Be(1);
         await _redmineService.Received(1).GetIssueAsync(issueId, false, Arg.Any<CancellationToken>());
-        await _redmineService.Received(1).UpdateIssueAsync(issueId, null, "Closed", null, null, Arg.Any<CancellationToken>());
+        await _redmineService.Received(1).UpdateIssueAsync(issueId, null, "Closed", null, null, null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -492,6 +504,261 @@ public class IssueEditCommandTests
         // Assert
         result.Should().Be(1);
         await _redmineService.DidNotReceive().GetIssueAsync(Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-        await _redmineService.DidNotReceive().UpdateIssueAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
+        await _redmineService.DidNotReceive().UpdateIssueAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Edit_Should_UpdateDescription_When_BodyOptionProvided()
+    {
+        // Arrange
+        var issueId = 999;
+        var newDescription = "This is the new description";
+        var currentIssue = new Issue
+        {
+            Id = issueId,
+            Subject = "Test Issue",
+            Description = "Old description",
+            Status = new IssueStatus { Id = 1, Name = "New" },
+            Project = new Project { Id = 1, Name = "Test Project" }
+        };
+        var updatedIssue = new Issue
+        {
+            Id = issueId,
+            Subject = "Test Issue",
+            Description = newDescription,
+            Status = new IssueStatus { Id = 1, Name = "New" },
+            Project = new Project { Id = 1, Name = "Test Project" }
+        };
+
+        _redmineService.GetIssueAsync(issueId, false, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(currentIssue));
+        _redmineService.UpdateIssueAsync(
+            issueId,
+            null,
+            null,
+            null,
+            newDescription,
+            null,
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(updatedIssue));
+
+        // Act
+        var result = await _issueCommand.EditAsync(issueId, null, null, null, newDescription, null, false, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(0);
+        await _redmineService.Received(1).GetIssueAsync(issueId, false, Arg.Any<CancellationToken>());
+        await _redmineService.Received(1).UpdateIssueAsync(
+            issueId,
+            null,
+            null,
+            null,
+            newDescription,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Edit_Should_UpdateDescription_When_BodyFileOptionProvided()
+    {
+        // Arrange
+        var issueId = 888;
+        var tempFile = Path.GetTempFileName();
+        var fileContent = "This is the description from file";
+        await File.WriteAllTextAsync(tempFile, fileContent);
+
+        try
+        {
+            var currentIssue = new Issue
+            {
+                Id = issueId,
+                Subject = "Test Issue",
+                Description = "Old description",
+                Status = new IssueStatus { Id = 1, Name = "New" },
+                Project = new Project { Id = 1, Name = "Test Project" }
+            };
+            var updatedIssue = new Issue
+            {
+                Id = issueId,
+                Subject = "Test Issue",
+                Description = fileContent,
+                Status = new IssueStatus { Id = 1, Name = "New" },
+                Project = new Project { Id = 1, Name = "Test Project" }
+            };
+
+            _redmineService.GetIssueAsync(issueId, false, Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(currentIssue));
+            _redmineService.UpdateIssueAsync(
+                issueId,
+                null,
+                null,
+                null,
+                fileContent,
+                null,
+                Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(updatedIssue));
+
+            // Act
+            var result = await _issueCommand.EditAsync(issueId, null, null, null, null, tempFile, false, CancellationToken.None);
+
+            // Assert
+            result.Should().Be(0);
+            await _redmineService.Received(1).GetIssueAsync(issueId, false, Arg.Any<CancellationToken>());
+            await _redmineService.Received(1).UpdateIssueAsync(
+                issueId,
+                null,
+                null,
+                null,
+                fileContent,
+                null,
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Edit_Should_UpdateDescription_When_BodyFileIsStdin()
+    {
+        // Arrange
+        var issueId = 777;
+        var stdinContent = "This is the description from stdin";
+        var currentIssue = new Issue
+        {
+            Id = issueId,
+            Subject = "Test Issue",
+            Description = "Old description",
+            Status = new IssueStatus { Id = 1, Name = "New" },
+            Project = new Project { Id = 1, Name = "Test Project" }
+        };
+        var updatedIssue = new Issue
+        {
+            Id = issueId,
+            Subject = "Test Issue",
+            Description = stdinContent,
+            Status = new IssueStatus { Id = 1, Name = "New" },
+            Project = new Project { Id = 1, Name = "Test Project" }
+        };
+
+        // Simulate stdin input
+        var originalInput = Console.In;
+        using var reader = new StringReader(stdinContent);
+        Console.SetIn(reader);
+
+        try
+        {
+            _redmineService.GetIssueAsync(issueId, false, Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(currentIssue));
+            _redmineService.UpdateIssueAsync(
+                issueId,
+                null,
+                null,
+                null,
+                stdinContent,
+                null,
+                Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(updatedIssue));
+
+            // Act
+            var result = await _issueCommand.EditAsync(issueId, null, null, null, null, "-", false, CancellationToken.None);
+
+            // Assert
+            result.Should().Be(0);
+            await _redmineService.Received(1).GetIssueAsync(issueId, false, Arg.Any<CancellationToken>());
+            await _redmineService.Received(1).UpdateIssueAsync(
+                issueId,
+                null,
+                null,
+                null,
+                stdinContent,
+                null,
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            Console.SetIn(originalInput);
+        }
+    }
+
+    [Fact]
+    public async Task Edit_Should_UpdateMultipleFieldsIncludingDescription_When_CombinedOptionsProvided()
+    {
+        // Arrange
+        var issueId = 666;
+        var newStatus = "resolved";
+        var newDescription = "Updated description with status change";
+        var statusList = new List<IssueStatus>
+        {
+            new IssueStatus { Id = 1, Name = "New" },
+            new IssueStatus { Id = 3, Name = "Resolved" }
+        };
+        var currentIssue = new Issue
+        {
+            Id = issueId,
+            Subject = "Test Issue",
+            Status = new IssueStatus { Id = 1, Name = "New" },
+            Project = new Project { Id = 1, Name = "Test Project" }
+        };
+        var updatedIssue = new Issue
+        {
+            Id = issueId,
+            Subject = "Test Issue",
+            Description = newDescription,
+            Status = new IssueStatus { Id = 3, Name = "Resolved" },
+            Project = new Project { Id = 1, Name = "Test Project" }
+        };
+
+        _redmineService.GetIssueAsync(issueId, false, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(currentIssue));
+        _redmineService.GetIssueStatusesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(statusList));
+        _redmineService.UpdateIssueAsync(
+            issueId,
+            null,
+            newStatus,
+            null,
+            newDescription,
+            null,
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(updatedIssue));
+
+        // Act
+        var result = await _issueCommand.EditAsync(issueId, newStatus, null, null, newDescription, null, false, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(0);
+        await _redmineService.Received(1).GetIssueAsync(issueId, false, Arg.Any<CancellationToken>());
+        await _redmineService.Received(1).UpdateIssueAsync(
+            issueId,
+            null,
+            newStatus,
+            null,
+            newDescription,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Edit_Should_ReturnError_When_BodyFileNotFound()
+    {
+        // Arrange
+        var issueId = 555;
+        var nonExistentFile = "non-existent-file.txt";
+
+        // Act
+        var result = await _issueCommand.EditAsync(issueId, null, null, null, null, nonExistentFile, false, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(1);
+        await _redmineService.DidNotReceive().UpdateIssueAsync(
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<int?>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/RedmineCLI.Tests/Commands/IssueEditCommandTests.cs
+++ b/RedmineCLI.Tests/Commands/IssueEditCommandTests.cs
@@ -79,8 +79,18 @@ public class IssueEditCommandTests
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
+        // Mock config service
+        var profile = new Profile
+        {
+            Name = "test",
+            Url = "https://redmine.example.com",
+            ApiKey = "test-key"
+        };
+        _configService.GetActiveProfileAsync()
+            .Returns(Task.FromResult<Profile?>(profile));
+
         // Act
-        var result = await _issueCommand.EditAsync(issueId, newStatus, null, null, false, CancellationToken.None);
+        var result = await _issueCommand.EditAsync(issueId, newStatus, null, null, null, null, false, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -136,8 +146,18 @@ public class IssueEditCommandTests
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
+        // Mock config service
+        var profile = new Profile
+        {
+            Name = "test",
+            Url = "https://redmine.example.com",
+            ApiKey = "test-key"
+        };
+        _configService.GetActiveProfileAsync()
+            .Returns(Task.FromResult<Profile?>(profile));
+
         // Act
-        var result = await _issueCommand.EditAsync(issueId, null, newAssignee, null, false, CancellationToken.None);
+        var result = await _issueCommand.EditAsync(issueId, null, newAssignee, null, null, null, false, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -187,8 +207,18 @@ public class IssueEditCommandTests
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
+        // Mock config service
+        var profile = new Profile
+        {
+            Name = "test",
+            Url = "https://redmine.example.com",
+            ApiKey = "test-key"
+        };
+        _configService.GetActiveProfileAsync()
+            .Returns(Task.FromResult<Profile?>(profile));
+
         // Act
-        var result = await _issueCommand.EditAsync(issueId, null, null, doneRatio, false, CancellationToken.None);
+        var result = await _issueCommand.EditAsync(issueId, null, null, doneRatio, null, null, false, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -247,12 +277,12 @@ public class IssueEditCommandTests
             .Returns(Task.FromResult(updatedIssue));
 
         // Act
-        var result = await _issueCommand.EditAsync(issueId, newStatus, null, null, false, CancellationToken.None);
+        var result = await _issueCommand.EditAsync(issueId, newStatus, null, null, null, null, false, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
         await _redmineService.Received(1).GetIssueAsync(issueId, false, Arg.Any<CancellationToken>());
-        await _redmineService.Received(1).UpdateIssueAsync(issueId, null, newStatus, null, null, Arg.Any<CancellationToken>());
+        await _redmineService.Received(1).UpdateIssueAsync(issueId, null, newStatus, null, null, null, Arg.Any<CancellationToken>());
         await _configService.Received(1).GetActiveProfileAsync();
     }
 
@@ -265,7 +295,7 @@ public class IssueEditCommandTests
         _configService.GetActiveProfileAsync().Returns(Task.FromResult<Profile?>(profile));
 
         // Act
-        var result = await _issueCommand.EditAsync(issueId, null, null, null, true, CancellationToken.None);
+        var result = await _issueCommand.EditAsync(issueId, null, null, null, null, null, true, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -308,8 +338,18 @@ public class IssueEditCommandTests
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
+        // Mock config service
+        var profile = new Profile
+        {
+            Name = "test",
+            Url = "https://redmine.example.com",
+            ApiKey = "test-key"
+        };
+        _configService.GetActiveProfileAsync()
+            .Returns(Task.FromResult<Profile?>(profile));
+
         // Act
-        var result = await _issueCommand.EditAsync(issueId, null, "@me", null, false, CancellationToken.None);
+        var result = await _issueCommand.EditAsync(issueId, null, "@me", null, null, null, false, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -377,8 +417,18 @@ public class IssueEditCommandTests
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
 
+        // Mock config service
+        var profile = new Profile
+        {
+            Name = "test",
+            Url = "https://redmine.example.com",
+            ApiKey = "test-key"
+        };
+        _configService.GetActiveProfileAsync()
+            .Returns(Task.FromResult<Profile?>(profile));
+
         // Act
-        var result = await _issueCommand.EditAsync(issueId, newStatus, newAssignee, doneRatio, false, CancellationToken.None);
+        var result = await _issueCommand.EditAsync(issueId, newStatus, newAssignee, doneRatio, null, null, false, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -421,7 +471,7 @@ public class IssueEditCommandTests
             .Returns(Task.FromException<Issue>(new RedmineApiException(404, "Issue not found")));
 
         // Act
-        var result = await _issueCommand.EditAsync(issueId, "Closed", null, null, false, CancellationToken.None);
+        var result = await _issueCommand.EditAsync(issueId, "Closed", null, null, null, null, false, CancellationToken.None);
 
         // Assert
         result.Should().Be(1);
@@ -437,7 +487,7 @@ public class IssueEditCommandTests
         _configService.GetActiveProfileAsync().Returns(Task.FromResult<Profile?>(null));
 
         // Act
-        var result = await _issueCommand.EditAsync(issueId, null, null, null, true, CancellationToken.None);
+        var result = await _issueCommand.EditAsync(issueId, null, null, null, null, null, true, CancellationToken.None);
 
         // Assert
         result.Should().Be(1);
@@ -463,7 +513,7 @@ public class IssueEditCommandTests
             .Returns(Task.FromResult(originalIssue));
 
         // Act
-        var result = await _issueCommand.EditAsync(issueId, null, null, null, false, CancellationToken.None);
+        var result = await _issueCommand.EditAsync(issueId, null, null, null, null, null, false, CancellationToken.None);
 
         // Assert
         // Since this would launch interactive mode, we can't fully test it in unit tests
@@ -499,7 +549,7 @@ public class IssueEditCommandTests
         var invalidDoneRatio = 150; // Out of 0-100 range
 
         // Act
-        var result = await _issueCommand.EditAsync(issueId, null, null, invalidDoneRatio, false, CancellationToken.None);
+        var result = await _issueCommand.EditAsync(issueId, null, null, invalidDoneRatio, null, null, false, CancellationToken.None);
 
         // Assert
         result.Should().Be(1);
@@ -541,6 +591,16 @@ public class IssueEditCommandTests
             null,
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
+
+        // Mock config service
+        var profile = new Profile
+        {
+            Name = "test",
+            Url = "https://redmine.example.com",
+            ApiKey = "test-key"
+        };
+        _configService.GetActiveProfileAsync()
+            .Returns(Task.FromResult<Profile?>(profile));
 
         // Act
         var result = await _issueCommand.EditAsync(issueId, null, null, null, newDescription, null, false, CancellationToken.None);
@@ -597,6 +657,16 @@ public class IssueEditCommandTests
                 null,
                 Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult(updatedIssue));
+
+            // Mock config service
+            var profile = new Profile
+            {
+                Name = "test",
+                Url = "https://redmine.example.com",
+                ApiKey = "test-key"
+            };
+            _configService.GetActiveProfileAsync()
+                .Returns(Task.FromResult<Profile?>(profile));
 
             // Act
             var result = await _issueCommand.EditAsync(issueId, null, null, null, null, tempFile, false, CancellationToken.None);
@@ -661,6 +731,16 @@ public class IssueEditCommandTests
                 Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult(updatedIssue));
 
+            // Mock config service
+            var profile = new Profile
+            {
+                Name = "test",
+                Url = "https://redmine.example.com",
+                ApiKey = "test-key"
+            };
+            _configService.GetActiveProfileAsync()
+                .Returns(Task.FromResult<Profile?>(profile));
+
             // Act
             var result = await _issueCommand.EditAsync(issueId, null, null, null, null, "-", false, CancellationToken.None);
 
@@ -723,6 +803,16 @@ public class IssueEditCommandTests
             null,
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(updatedIssue));
+
+        // Mock config service
+        var profile = new Profile
+        {
+            Name = "test",
+            Url = "https://redmine.example.com",
+            ApiKey = "test-key"
+        };
+        _configService.GetActiveProfileAsync()
+            .Returns(Task.FromResult<Profile?>(profile));
 
         // Act
         var result = await _issueCommand.EditAsync(issueId, newStatus, null, null, newDescription, null, false, CancellationToken.None);

--- a/RedmineCLI/Commands/IssueCommand.cs
+++ b/RedmineCLI/Commands/IssueCommand.cs
@@ -193,6 +193,10 @@ public class IssueCommand
         var editAssigneeOption = new Option<string?>("--assignee") { Description = "New assignee (username, ID, or @me)" };
         editAssigneeOption.Aliases.Add("-a");
         var editDoneRatioOption = new Option<int?>("--done-ratio") { Description = "Progress percentage (0-100)" };
+        var editBodyOption = new Option<string?>("--body") { Description = "New description text" };
+        editBodyOption.Aliases.Add("-b");
+        var editBodyFileOption = new Option<string?>("--body-file") { Description = "Read description from file (use '-' for stdin)" };
+        editBodyFileOption.Aliases.Add("-F");
         var editWebOption = new Option<bool>("--web") { Description = "Open edit page in web browser" };
         editWebOption.Aliases.Add("-w");
 
@@ -200,6 +204,8 @@ public class IssueCommand
         editCommand.Add(editStatusOption);
         editCommand.Add(editAssigneeOption);
         editCommand.Add(editDoneRatioOption);
+        editCommand.Add(editBodyOption);
+        editCommand.Add(editBodyFileOption);
         editCommand.Add(editWebOption);
 
         editCommand.SetAction(async (parseResult) =>
@@ -208,9 +214,11 @@ public class IssueCommand
             var status = parseResult.GetValue(editStatusOption);
             var assignee = parseResult.GetValue(editAssigneeOption);
             var doneRatio = parseResult.GetValue(editDoneRatioOption);
+            var body = parseResult.GetValue(editBodyOption);
+            var bodyFile = parseResult.GetValue(editBodyFileOption);
             var web = parseResult.GetValue(editWebOption);
 
-            Environment.ExitCode = await issueCommand.EditAsync(id, status, assignee, doneRatio, web, CancellationToken.None);
+            Environment.ExitCode = await issueCommand.EditAsync(id, status, assignee, doneRatio, body, bodyFile, web, CancellationToken.None);
         });
 
         command.Add(editCommand);
@@ -1310,13 +1318,15 @@ public class IssueCommand
         string? status,
         string? assignee,
         int? doneRatio,
+        string? body,
+        string? bodyFile,
         bool web,
         CancellationToken cancellationToken)
     {
         try
         {
-            _logger.LogDebug("Editing issue {IssueId} - Status: {Status}, Assignee: {Assignee}, DoneRatio: {DoneRatio}, Web: {Web}",
-                issueId, status, assignee, doneRatio, web);
+            _logger.LogDebug("Editing issue {IssueId} - Status: {Status}, Assignee: {Assignee}, DoneRatio: {DoneRatio}, Body: {Body}, BodyFile: {BodyFile}, Web: {Web}",
+                issueId, status, assignee, doneRatio, body != null ? "[provided]" : null, bodyFile, web);
 
             // Handle --web option
             if (web)
@@ -1335,7 +1345,8 @@ public class IssueCommand
             }
 
             // If no options provided, launch interactive mode
-            if (string.IsNullOrEmpty(status) && string.IsNullOrEmpty(assignee) && !doneRatio.HasValue)
+            if (string.IsNullOrEmpty(status) && string.IsNullOrEmpty(assignee) && !doneRatio.HasValue &&
+                string.IsNullOrEmpty(body) && string.IsNullOrEmpty(bodyFile))
             {
                 return await EditInteractiveAsync(issueId, cancellationToken);
             }
@@ -1385,6 +1396,44 @@ public class IssueCommand
                 updateDetails["progress"] = $"{doneRatio.Value}%";
             }
 
+            // Handle description (body)
+            string? description = null;
+            if (!string.IsNullOrEmpty(body))
+            {
+                description = body;
+                fieldsToUpdate.Add("description");
+                updateDetails["description"] = "updated";
+            }
+            else if (!string.IsNullOrEmpty(bodyFile))
+            {
+                try
+                {
+                    if (bodyFile == "-")
+                    {
+                        // Read from stdin
+                        using var reader = new StreamReader(Console.OpenStandardInput());
+                        description = await reader.ReadToEndAsync();
+                    }
+                    else
+                    {
+                        // Read from file
+                        if (!File.Exists(bodyFile))
+                        {
+                            AnsiConsole.MarkupLine($"[red]Error:[/] File not found: {bodyFile}");
+                            return 1;
+                        }
+                        description = await File.ReadAllTextAsync(bodyFile, cancellationToken);
+                    }
+                    fieldsToUpdate.Add("description");
+                    updateDetails["description"] = "updated from file";
+                }
+                catch (Exception ex)
+                {
+                    AnsiConsole.MarkupLine($"[red]Error:[/] Failed to read body file: {ex.Message}");
+                    return 1;
+                }
+            }
+
             // Log what we're updating
             _logger.LogDebug("Updating issue {IssueId} fields: {Fields}", issueId, string.Join(", ", fieldsToUpdate));
 
@@ -1394,6 +1443,7 @@ public class IssueCommand
                 null, // subject - keep existing
                 statusIdOrName,
                 assigneeIdOrUsername,
+                description,
                 doneRatio,
                 cancellationToken);
 
@@ -1404,6 +1454,7 @@ public class IssueCommand
                     "status" => $"status → {updateDetails.GetValueOrDefault("status", "unknown")}",
                     "assignee" => $"assignee → {updateDetails.GetValueOrDefault("assignee", "unknown")}",
                     "progress" => $"progress → {updateDetails.GetValueOrDefault("progress", "unknown")}",
+                    "description" => $"description → {updateDetails.GetValueOrDefault("description", "unknown")}",
                     _ => f
                 }));
 
@@ -1559,6 +1610,7 @@ public class IssueCommand
                 null, // subject - keep existing
                 statusIdOrName,
                 assigneeIdOrUsername,
+                updateIssue.Description,
                 updateIssue.DoneRatio,
                 cancellationToken);
 
@@ -2104,6 +2156,7 @@ public class IssueCommand
                         null, // keep existing subject
                         closeStatusId,
                         null, // keep existing assignee
+                        null, // keep existing description
                         doneRatio,
                         cancellationToken);
 

--- a/RedmineCLI/Commands/IssueCommand.cs
+++ b/RedmineCLI/Commands/IssueCommand.cs
@@ -1411,8 +1411,7 @@ public class IssueCommand
                     if (bodyFile == "-")
                     {
                         // Read from stdin
-                        using var reader = new StreamReader(Console.OpenStandardInput());
-                        description = await reader.ReadToEndAsync();
+                        description = await Console.In.ReadToEndAsync();
                     }
                     else
                     {

--- a/RedmineCLI/Services/IRedmineService.cs
+++ b/RedmineCLI/Services/IRedmineService.cs
@@ -48,6 +48,7 @@ public interface IRedmineService
         string? subject = null,
         string? statusIdOrName = null,
         string? assigneeIdOrUsername = null,
+        string? description = null,
         int? doneRatio = null,
         CancellationToken cancellationToken = default);
 

--- a/RedmineCLI/Services/RedmineService.cs
+++ b/RedmineCLI/Services/RedmineService.cs
@@ -118,6 +118,7 @@ public class RedmineService : IRedmineService
         string? subject = null,
         string? statusIdOrName = null,
         string? assigneeIdOrUsername = null,
+        string? description = null,
         int? doneRatio = null,
         CancellationToken cancellationToken = default)
     {
@@ -131,6 +132,12 @@ public class RedmineService : IRedmineService
             Id = id,
             Subject = subject ?? existingIssue.Subject
         };
+
+        // 説明の更新
+        if (description != null)
+        {
+            updateData.Description = description;
+        }
 
         // ステータスの解決
         if (!string.IsNullOrEmpty(statusIdOrName))


### PR DESCRIPTION
## 概要
`redmine issue edit`コマンドに、チケットの説明欄（description）を更新する機能を追加しました。

## 変更内容
- `--body` / `-b` オプション: 説明欄のテキストを直接指定
- `--body-file` / `-F` オプション: ファイルから説明欄を読み込み（"-"で標準入力）
- TDDアプローチでテストを追加
- 既存のUpdateIssueAsyncメソッドに説明欄パラメータを追加
- README.mdにコマンド例を追加

GitHub CLI (`gh issue edit`) の実装を参考にしました。

Closes #96

Generated with [Claude Code](https://claude.ai/code)