### PR TITLE
feat: redmine issue editで--add-assigneeと--remove-assigneeオプションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,14 @@ redmine issue edit 12345 -F description.md
 echo "新しい説明文" | redmine issue edit 12345 -F -
 
 # 複数のフィールドを同時に更新
-redmine issue edit 12345 --status=resolved --assignee=@me --body "問題を解決しました"
-redmine issue edit 12345 -t "バグ修正完了" -s in-progress -a @me
+redmine issue edit 12345 --status=resolved --add-assignee=@me --body "問題を解決しました"
+
+# 担当者を設定
+redmine issue edit 12345 --add-assignee=@me
+redmine issue edit 12345 --add-assignee=john.doe
+
+# 担当者を削除
+redmine issue edit 12345 --remove-assignee
 
 # コメントを追加
 redmine issue comment 12345 --message "作業を開始しました"

--- a/RedmineCLI/Services/RedmineService.cs
+++ b/RedmineCLI/Services/RedmineService.cs
@@ -152,10 +152,18 @@ public class RedmineService : IRedmineService
         // 担当者の解決
         if (!string.IsNullOrEmpty(assigneeIdOrUsername))
         {
-            var resolvedAssignee = await ResolveAssigneeAsync(assigneeIdOrUsername, cancellationToken);
-            if (int.TryParse(resolvedAssignee, out var assigneeId))
+            if (assigneeIdOrUsername == "__REMOVE__")
             {
-                updateData.AssignedTo = new User { Id = assigneeId };
+                // 担当者を削除するために特別な値を設定
+                updateData.AssignedTo = new User { Id = -1 };
+            }
+            else
+            {
+                var resolvedAssignee = await ResolveAssigneeAsync(assigneeIdOrUsername, cancellationToken);
+                if (int.TryParse(resolvedAssignee, out var assigneeId))
+                {
+                    updateData.AssignedTo = new User { Id = assigneeId };
+                }
             }
         }
 


### PR DESCRIPTION
fixes #102

## 概要

redmine issue editコマンドの担当者オプションをGitHub CLIのパターンに合わせて改善しました。

## 変更内容

- `-a, --assignee`オプションを`--add-assignee`に変更（エイリアスなし）
- `--remove-assignee`オプションを追加（担当者を削除）
- Redmine APIに空文字列を送信して担当者を削除する機能を実装
- テストを追加・更新
- ドキュメントを更新

Generated with [Claude Code](https://claude.ai/code)