### PR TITLE
perf: CI/CDパイプラインの並列実行化によるビルド時間短縮

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,6 +28,14 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json', '**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
     - name: Restore dependencies
       run: dotnet restore
 
@@ -112,6 +120,13 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json', '**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
 
     - name: Restore dependencies
       run: dotnet restore
@@ -170,6 +185,14 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json', '**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
 
     - name: Restore dependencies
       run: dotnet restore


### PR DESCRIPTION
## 概要
GitHub ActionsのビルドワークフローでAOTビルドとベンチマークテストを最初から並列実行するように改善しました。

## 変更内容
- `build-native`ジョブから`needs: test`の依存関係を削除
- `benchmark`ジョブを独立させ、専用のLinux x64 AOTビルドを実行するように変更
- 3つのジョブ（`test`、`build-native`、`benchmark`）が同時に並列実行

## 効果
- **CI/CDパイプライン全体の実行時間を大幅に短縮**
  - 従来: test → build-native → benchmark（シーケンシャル実行）
  - 改善後: test、build-native、benchmark（並列実行）
- 各ジョブが独立して実行されるため、早期にフィードバックを取得可能
- テストが失敗してもAOTビルドの問題を並行して発見可能

## テスト
- [ ] GitHub Actionsで正常に動作することを確認
- [ ] 3つのジョブが並列実行されることを確認
- [ ] benchmarkジョブでLinux x64バイナリが正しくビルド・実行されることを確認