### PR TITLE
refactor: --body オプションを --description に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,18 +132,18 @@ redmine issue edit 12345 --title "新しいタイトル"
 redmine issue edit 12345 -t "新しいタイトル"
 
 # チケットの説明を更新
-redmine issue edit 12345 --body "新しい説明文"
-redmine issue edit 12345 -b "新しい説明文"
+redmine issue edit 12345 --description "新しい説明文"
+redmine issue edit 12345 -d "新しい説明文"
 
 # ファイルから説明を読み込んで更新
-redmine issue edit 12345 --body-file description.md
-redmine issue edit 12345 -F description.md
+redmine issue edit 12345 --description-file description.md
+redmine issue edit 12345 -D description.md
 
 # 標準入力から説明を読み込んで更新
-echo "新しい説明文" | redmine issue edit 12345 -F -
+echo "新しい説明文" | redmine issue edit 12345 -D -
 
 # 複数のフィールドを同時に更新
-redmine issue edit 12345 --status=resolved --add-assignee=@me --body "問題を解決しました"
+redmine issue edit 12345 --status=resolved --add-assignee=@me --description "問題を解決しました"
 
 # 担当者を設定
 redmine issue edit 12345 --add-assignee=@me
@@ -157,19 +157,19 @@ redmine issue comment 12345 --message "作業を開始しました"
 redmine issue comment 12345 -m "確認しました"
 
 # チケットの説明欄を更新（コメント追加なし）
-redmine issue comment 12345 --body "更新された説明文"
-redmine issue comment 12345 -b "更新された説明文"
+redmine issue comment 12345 --description "更新された説明文"
+redmine issue comment 12345 -d "更新された説明文"
 
 # ファイルから説明欄を読み込んで更新
-redmine issue comment 12345 --body-file description.md
-redmine issue comment 12345 -F description.md
+redmine issue comment 12345 --description-file description.md
+redmine issue comment 12345 -D description.md
 
 # 標準入力から説明欄を読み込んで更新
-echo "新しい説明" | redmine issue comment 12345 --body-file -
-cat description.md | redmine issue comment 12345 -F -
+echo "新しい説明" | redmine issue comment 12345 --description-file -
+cat description.md | redmine issue comment 12345 -D -
 
 # コメント追加と説明欄更新を同時に実行
-redmine issue comment 12345 -m "説明を更新しました" --body "新しい説明文"
+redmine issue comment 12345 -m "説明を更新しました" --description "新しい説明文"
 ```
 
 ### 優先度管理

--- a/RedmineCLI.Tests/Commands/IssueEditCommandTests.cs
+++ b/RedmineCLI.Tests/Commands/IssueEditCommandTests.cs
@@ -690,8 +690,8 @@ public class IssueEditCommandTests
         optionNames.Should().Contain("--add-assignee");
         optionNames.Should().Contain("--remove-assignee");
         optionNames.Should().Contain("--done-ratio");
-        optionNames.Should().Contain("--body");
-        optionNames.Should().Contain("--body-file");
+        optionNames.Should().Contain("--description");
+        optionNames.Should().Contain("--description-file");
         optionNames.Should().Contain("--web");
 
         var argNames = editCommand.Arguments.Select(a => a.Name).ToList();

--- a/RedmineCLI/Commands/IssueCommand.cs
+++ b/RedmineCLI/Commands/IssueCommand.cs
@@ -195,10 +195,10 @@ public class IssueCommand
         var editAddAssigneeOption = new Option<string?>("--add-assignee") { Description = "New assignee (username, ID, or @me)" };
         var editRemoveAssigneeOption = new Option<bool>("--remove-assignee") { Description = "Remove assignee" };
         var editDoneRatioOption = new Option<int?>("--done-ratio") { Description = "Progress percentage (0-100)" };
-        var editBodyOption = new Option<string?>("--body") { Description = "New description text" };
-        editBodyOption.Aliases.Add("-b");
-        var editBodyFileOption = new Option<string?>("--body-file") { Description = "Read description from file (use '-' for stdin)" };
-        editBodyFileOption.Aliases.Add("-F");
+        var editBodyOption = new Option<string?>("--description") { Description = "New description text" };
+        editBodyOption.Aliases.Add("-d");
+        var editBodyFileOption = new Option<string?>("--description-file") { Description = "Read description from file (use '-' for stdin)" };
+        editBodyFileOption.Aliases.Add("-D");
         var editWebOption = new Option<bool>("--web") { Description = "Open edit page in web browser" };
         editWebOption.Aliases.Add("-w");
 
@@ -250,10 +250,10 @@ public class IssueCommand
         commentIdArgument.Description = "Issue ID";
         var commentMessageOption = new Option<string?>("--message") { Description = "Comment text" };
         commentMessageOption.Aliases.Add("-m");
-        var commentBodyOption = new Option<string?>("--body") { Description = "New description text" };
-        commentBodyOption.Aliases.Add("-b");
-        var commentBodyFileOption = new Option<string?>("--body-file") { Description = "Read description from file (use '-' for stdin)" };
-        commentBodyFileOption.Aliases.Add("-F");
+        var commentBodyOption = new Option<string?>("--description") { Description = "New description text" };
+        commentBodyOption.Aliases.Add("-d");
+        var commentBodyFileOption = new Option<string?>("--description-file") { Description = "Read description from file (use '-' for stdin)" };
+        commentBodyFileOption.Aliases.Add("-D");
         var commentAddAssigneeOption = new Option<string?>("--add-assignee") { Description = "New assignee (username, ID, or @me)" };
         var commentRemoveAssigneeOption = new Option<bool>("--remove-assignee") { Description = "Remove assignee" };
 
@@ -1720,7 +1720,7 @@ public class IssueCommand
             // Check if at least one action is provided
             if (string.IsNullOrEmpty(message) && string.IsNullOrEmpty(body) && string.IsNullOrEmpty(bodyFile) && string.IsNullOrEmpty(assignee))
             {
-                AnsiConsole.MarkupLine("[red]Error:[/] At least one of --message, --body, --body-file, --add-assignee, or --remove-assignee must be provided");
+                AnsiConsole.MarkupLine("[red]Error:[/] At least one of --message, --description, --description-file, --add-assignee, or --remove-assignee must be provided");
                 return 1;
             }
 


### PR DESCRIPTION
## 概要

#108 に基づいて、`--body` オプションを `--description` に変更しました。これにより、RedmineCLI 全体で一貫性のあるインターフェースを提供します。

## 変更内容

### コマンドオプションの変更

- `issue edit` コマンド:
  - `--body/-b` → `--description/-d`
  - `--body-file/-F` → `--description-file/-D`
- `issue comment` コマンド:
  - `--body/-b` → `--description/-d`
  - `--body-file/-F` → `--description-file/-D`

### テストの更新

- `IssueEditCommandTests.cs`: オプション名のテストを更新

### ドキュメントの更新

- `README.md`: すべての使用例を新しいオプション名に更新

## 背景

- `issue create` コマンドでは既に `--description` を使用している
- 設計書（DESIGN.md）でも `-d / --description` の使用が定義されている
- Redmine API では `description` という用語を使用している
- 下位互換性は不要（まだリリースされていない）

Fixes #108

Generated with [Claude Code](https://claude.ai/code)