### PR TITLE
feat: issue commentコマンドに--title、--status、--done-ratioオプションを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ obj/
 *.swp
 *~
 
+# Serena cache and project files
+.serena/
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/RedmineCLI.Tests/Commands/IssueCommentCommandTests.cs
+++ b/RedmineCLI.Tests/Commands/IssueCommentCommandTests.cs
@@ -187,7 +187,7 @@ public class IssueCommentCommandTests
         _configService.GetActiveProfileAsync().Returns(profile);
 
         // Act
-        var result = await _issueCommand.CommentAsync(issueId, null, body, null, null, CancellationToken.None);
+        var result = await _issueCommand.CommentAsync(issueId, null, null, null, null, body, null, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -219,7 +219,7 @@ public class IssueCommentCommandTests
         try
         {
             // Act
-            var result = await _issueCommand.CommentAsync(issueId, null, null, tempFile, null, CancellationToken.None);
+            var result = await _issueCommand.CommentAsync(issueId, null, null, null, null, null, tempFile, null, CancellationToken.None);
 
             // Assert
             result.Should().Be(0);
@@ -256,7 +256,7 @@ public class IssueCommentCommandTests
         _configService.GetActiveProfileAsync().Returns(profile);
 
         // Act
-        var result = await _issueCommand.CommentAsync(issueId, message, body, null, null, CancellationToken.None);
+        var result = await _issueCommand.CommentAsync(issueId, message, null, null, null, body, null, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -271,7 +271,7 @@ public class IssueCommentCommandTests
         const int issueId = 123;
 
         // Act
-        var result = await _issueCommand.CommentAsync(issueId, null, null, null, null, CancellationToken.None);
+        var result = await _issueCommand.CommentAsync(issueId, null, null, null, null, null, null, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(1);
@@ -287,7 +287,7 @@ public class IssueCommentCommandTests
         const string nonExistentFile = "/path/to/nonexistent/file.txt";
 
         // Act
-        var result = await _issueCommand.CommentAsync(issueId, null, null, nonExistentFile, null, CancellationToken.None);
+        var result = await _issueCommand.CommentAsync(issueId, null, null, null, null, null, nonExistentFile, null, CancellationToken.None);
 
         // Assert
         result.Should().Be(1);
@@ -321,7 +321,7 @@ public class IssueCommentCommandTests
         try
         {
             // Act
-            var result = await _issueCommand.CommentAsync(issueId, null, null, "-", null, CancellationToken.None);
+            var result = await _issueCommand.CommentAsync(issueId, null, null, null, null, null, "-", null, CancellationToken.None);
 
             // Assert
             result.Should().Be(0);
@@ -358,7 +358,7 @@ public class IssueCommentCommandTests
             .Returns(Task.FromResult(currentUser));
 
         // Act
-        var result = await _issueCommand.CommentAsync(issueId, message, null, null, assignee, CancellationToken.None);
+        var result = await _issueCommand.CommentAsync(issueId, message, null, null, null, null, null, assignee, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -382,7 +382,7 @@ public class IssueCommentCommandTests
         _configService.GetActiveProfileAsync().Returns(profile);
 
         // Act
-        var result = await _issueCommand.CommentAsync(issueId, message, null, null, assignee, CancellationToken.None);
+        var result = await _issueCommand.CommentAsync(issueId, message, null, null, null, null, null, assignee, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
@@ -412,7 +412,7 @@ public class IssueCommentCommandTests
             .Returns(Task.FromResult(users));
 
         // Act
-        var result = await _issueCommand.CommentAsync(issueId, null, null, null, assignee, CancellationToken.None);
+        var result = await _issueCommand.CommentAsync(issueId, null, null, null, null, null, null, assignee, CancellationToken.None);
 
         // Assert
         result.Should().Be(0);

--- a/RedmineCLI/Commands/IssueCommentOptions.cs
+++ b/RedmineCLI/Commands/IssueCommentOptions.cs
@@ -1,0 +1,47 @@
+namespace RedmineCLI.Commands;
+
+/// <summary>
+/// CommentAsyncメソッドのパラメータをまとめたオプションクラス
+/// </summary>
+public class IssueCommentOptions
+{
+    /// <summary>
+    /// チケットID
+    /// </summary>
+    public int IssueId { get; set; }
+
+    /// <summary>
+    /// コメントのテキスト
+    /// </summary>
+    public string? Message { get; set; }
+
+    /// <summary>
+    /// チケットの新しいタイトル
+    /// </summary>
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// チケットの新しいステータス
+    /// </summary>
+    public string? Status { get; set; }
+
+    /// <summary>
+    /// 進捗率（0-100）
+    /// </summary>
+    public int? DoneRatio { get; set; }
+
+    /// <summary>
+    /// 新しい説明文
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// 説明文を読み込むファイルパス（'-' で標準入力）
+    /// </summary>
+    public string? DescriptionFile { get; set; }
+
+    /// <summary>
+    /// 新しい担当者（ユーザー名、ID、または @me）
+    /// </summary>
+    public string? Assignee { get; set; }
+}


### PR DESCRIPTION
## 概要
issue #112 の対応として、`redmine issue comment`コマンドに`issue edit`コマンドと同様のオプションを追加しました。

## 変更内容
- `--title` / `-t`: チケットのタイトルを変更
- `--status` / `-s`: ステータスを変更（open, closed, ステータス名またはID）
- `--done-ratio`: 進捗率を設定（0-100）

## 実装詳細
- `IssueCommentOptions`クラスを作成してパラメータを整理
- `CommentAsync`メソッドをリファクタリングして新しいオプションクラスを使用
- 後方互換性のためのオーバーロードメソッドを提供
- 既存のテストをすべて更新して新しいパラメータに対応

## 使用例
```bash
# コメントを追加しながらステータスと進捗率を更新
redmine issue comment 123 --message "作業完了" --status closed --done-ratio 100

# コメントとタイトル変更を同時に実行
redmine issue comment 123 --message "仕様変更に伴うタイトル更新" --title "【更新】新機能の実装"

# 進捗報告と共に進捗率を更新
redmine issue comment 123 --message "実装50%完了" --done-ratio 50
```

## テスト
- ✅ 既存のテストがすべてパス
- ✅ ビルドエラーなし
- ✅ 後方互換性を維持

Closes #112