### PR TITLE
feat: redmine-boardをGitHub Actionsリリースワークフローに追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,43 +154,46 @@ jobs:
 
     - name: Publish Native AOT - RedmineCLI
       run: |
-        dotnet publish RedmineCLI/RedmineCLI.csproj -c Release -r ${{ matrix.config.rid }} -p:PublishAot=true -p:StripSymbols=true -p:Version=${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }} -p:IncludeSourceRevisionInInformationalVersion=false --self-contained -o publish/${{ matrix.config.rid }}/redmine-cli
+        dotnet publish RedmineCLI/RedmineCLI.csproj -c Release -r ${{ matrix.config.rid }} -p:PublishAot=true -p:StripSymbols=true -p:Version=${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }} -p:IncludeSourceRevisionInInformationalVersion=false --self-contained -o publish/${{ matrix.config.rid }}
 
     - name: Publish Native AOT - Redmine Board
       run: |
-        dotnet publish RedmineCLI.Extension.Board/RedmineCLI.Extension.Board.csproj -c Release -r ${{ matrix.config.rid }} -p:PublishAot=true -p:StripSymbols=true -p:Version=${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }} -p:IncludeSourceRevisionInInformationalVersion=false --self-contained -o publish/${{ matrix.config.rid }}/redmine-board
+        dotnet publish RedmineCLI.Extension.Board/RedmineCLI.Extension.Board.csproj -c Release -r ${{ matrix.config.rid }} -p:PublishAot=true -p:StripSymbols=true -p:Version=${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }} -p:IncludeSourceRevisionInInformationalVersion=false --self-contained -o publish-board/${{ matrix.config.rid }}
 
-    - name: Compress binaries to zip (Windows)
+    - name: Compress binary to zip (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        # Compress redmine-cli
-        cd publish/${{ matrix.config.rid }}/redmine-cli
-        Compress-Archive -Path ${{ matrix.config.output }} -DestinationPath ../../../${{ env.ASSET_NAME_PREFIX }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
-        cd ../../..
-        
-        # Compress redmine-board
-        cd publish/${{ matrix.config.rid }}/redmine-board
-        $boardOutput = if ('${{ matrix.config.rid }}' -like 'win-*') { 'redmine-board.exe' } else { 'redmine-board' }
-        Compress-Archive -Path $boardOutput -DestinationPath ../../../redmine-board-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
-        cd ../../..
+        cd publish/${{ matrix.config.rid }}
+        Compress-Archive -Path ${{ matrix.config.output }} -DestinationPath ../../${{ env.ASSET_NAME_PREFIX }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
+        cd ../..
 
-    - name: Compress binaries to zip (Unix)
+    - name: Compress redmine-board to zip (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        cd publish-board/${{ matrix.config.rid }}
+        $boardOutput = if ('${{ matrix.config.rid }}' -like 'win-*') { 'redmine-board.exe' } else { 'redmine-board' }
+        Compress-Archive -Path $boardOutput -DestinationPath ../../redmine-board-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
+        cd ../..
+
+    - name: Compress binary to zip (Unix)
       if: runner.os != 'Windows'
       run: |
-        # Compress redmine-cli
-        cd publish/${{ matrix.config.rid }}/redmine-cli
-        zip -j ../../../${{ env.ASSET_NAME_PREFIX }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip ${{ matrix.config.output }}
-        cd ../../..
-        
-        # Compress redmine-board
-        cd publish/${{ matrix.config.rid }}/redmine-board
+        cd publish/${{ matrix.config.rid }}
+        zip -j ../../${{ env.ASSET_NAME_PREFIX }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip ${{ matrix.config.output }}
+        cd ../..
+
+    - name: Compress redmine-board to zip (Unix)
+      if: runner.os != 'Windows'
+      run: |
+        cd publish-board/${{ matrix.config.rid }}
         BOARD_OUTPUT="redmine-board"
         if [[ "${{ matrix.config.rid }}" == win-* ]]; then
           BOARD_OUTPUT="redmine-board.exe"
         fi
-        zip -j ../../../redmine-board-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip $BOARD_OUTPUT
-        cd ../../..
+        zip -j ../../redmine-board-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip $BOARD_OUTPUT
+        cd ../..
 
     - name: Upload Release Assets
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,19 @@ jobs:
         echo "- Cross-platform support (Windows, macOS, Linux)" >> $GITHUB_OUTPUT
         echo "- Interactive and non-interactive command modes" >> $GITHUB_OUTPUT
         echo "- Web browser integration with --web option" >> $GITHUB_OUTPUT
+        echo "- **redmine-board**: Board extension with form-based authentication" >> $GITHUB_OUTPUT
         echo "" >> $GITHUB_OUTPUT
         echo "## 📥 Installation" >> $GITHUB_OUTPUT
         echo "" >> $GITHUB_OUTPUT
         echo "Download the appropriate binary for your platform from the assets below." >> $GITHUB_OUTPUT
         echo "" >> $GITHUB_OUTPUT
+        echo "### Available Binaries" >> $GITHUB_OUTPUT
+        echo "- **redmine-cli**: Main RedmineCLI application" >> $GITHUB_OUTPUT
+        echo "- **redmine-board**: Board extension for project management" >> $GITHUB_OUTPUT
+        echo "" >> $GITHUB_OUTPUT
         echo "## 🛠️ Usage" >> $GITHUB_OUTPUT
         echo "" >> $GITHUB_OUTPUT
+        echo "### RedmineCLI" >> $GITHUB_OUTPUT
         echo "\`\`\`bash" >> $GITHUB_OUTPUT
         echo "# Setup authentication" >> $GITHUB_OUTPUT
         echo "redmine auth login" >> $GITHUB_OUTPUT
@@ -63,6 +69,13 @@ jobs:
         echo "redmine issue view 123" >> $GITHUB_OUTPUT
         echo "redmine issue edit 123" >> $GITHUB_OUTPUT
         echo "redmine issue comment 123" >> $GITHUB_OUTPUT
+        echo "\`\`\`" >> $GITHUB_OUTPUT
+        echo "" >> $GITHUB_OUTPUT
+        echo "### Redmine Board" >> $GITHUB_OUTPUT
+        echo "\`\`\`bash" >> $GITHUB_OUTPUT
+        echo "# List boards" >> $GITHUB_OUTPUT
+        echo "redmine-board list" >> $GITHUB_OUTPUT
+        echo "redmine-board list --project <project-id>" >> $GITHUB_OUTPUT
         echo "\`\`\`" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
 
@@ -139,30 +152,52 @@ jobs:
         VERSION=${GITHUB_REF#refs/tags/v}
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-    - name: Publish Native AOT
+    - name: Publish Native AOT - RedmineCLI
       run: |
-        dotnet publish RedmineCLI/RedmineCLI.csproj -c Release -r ${{ matrix.config.rid }} -p:PublishAot=true -p:StripSymbols=true -p:Version=${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }} -p:IncludeSourceRevisionInInformationalVersion=false --self-contained -o publish/${{ matrix.config.rid }}
+        dotnet publish RedmineCLI/RedmineCLI.csproj -c Release -r ${{ matrix.config.rid }} -p:PublishAot=true -p:StripSymbols=true -p:Version=${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }} -p:IncludeSourceRevisionInInformationalVersion=false --self-contained -o publish/${{ matrix.config.rid }}/redmine-cli
 
-    - name: Compress binary to zip (Windows)
+    - name: Publish Native AOT - Redmine Board
+      run: |
+        dotnet publish RedmineCLI.Extension.Board/RedmineCLI.Extension.Board.csproj -c Release -r ${{ matrix.config.rid }} -p:PublishAot=true -p:StripSymbols=true -p:Version=${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }} -p:IncludeSourceRevisionInInformationalVersion=false --self-contained -o publish/${{ matrix.config.rid }}/redmine-board
+
+    - name: Compress binaries to zip (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        cd publish/${{ matrix.config.rid }}
-        Compress-Archive -Path ${{ matrix.config.output }} -DestinationPath ../../${{ env.ASSET_NAME_PREFIX }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
-        cd ../..
+        # Compress redmine-cli
+        cd publish/${{ matrix.config.rid }}/redmine-cli
+        Compress-Archive -Path ${{ matrix.config.output }} -DestinationPath ../../../${{ env.ASSET_NAME_PREFIX }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
+        cd ../../..
+        
+        # Compress redmine-board
+        cd publish/${{ matrix.config.rid }}/redmine-board
+        $boardOutput = if ('${{ matrix.config.rid }}' -like 'win-*') { 'redmine-board.exe' } else { 'redmine-board' }
+        Compress-Archive -Path $boardOutput -DestinationPath ../../../redmine-board-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
+        cd ../../..
 
-    - name: Compress binary to zip (Unix)
+    - name: Compress binaries to zip (Unix)
       if: runner.os != 'Windows'
       run: |
-        cd publish/${{ matrix.config.rid }}
-        zip -j ../../${{ env.ASSET_NAME_PREFIX }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip ${{ matrix.config.output }}
-        cd ../..
+        # Compress redmine-cli
+        cd publish/${{ matrix.config.rid }}/redmine-cli
+        zip -j ../../../${{ env.ASSET_NAME_PREFIX }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip ${{ matrix.config.output }}
+        cd ../../..
+        
+        # Compress redmine-board
+        cd publish/${{ matrix.config.rid }}/redmine-board
+        BOARD_OUTPUT="redmine-board"
+        if [[ "${{ matrix.config.rid }}" == win-* ]]; then
+          BOARD_OUTPUT="redmine-board.exe"
+        fi
+        zip -j ../../../redmine-board-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip $BOARD_OUTPUT
+        cd ../../..
 
     - name: Upload Release Assets
       uses: softprops/action-gh-release@v2
       with:
         files: |
           ${{ env.ASSET_NAME_PREFIX }}-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
+          redmine-board-${{ steps.extract_version_windows.outputs.version || steps.extract_version_unix.outputs.version }}-${{ matrix.config.rid }}.zip
 
   generate-checksums:
     name: Generate Checksums
@@ -189,13 +224,14 @@ jobs:
     - name: Generate checksums
       run: |
         cd downloads
-        sha256sum *.zip > ../redmine-cli-${{ steps.extract_version.outputs.version }}-checksums.txt
+        # Generate checksums for all binaries
+        sha256sum *.zip > ../checksums-${{ steps.extract_version.outputs.version }}.txt
         cd ..
-        cat redmine-cli-${{ steps.extract_version.outputs.version }}-checksums.txt
+        cat checksums-${{ steps.extract_version.outputs.version }}.txt
     
     - name: Upload checksums
       uses: softprops/action-gh-release@v2
       with:
-        files: redmine-cli-${{ steps.extract_version.outputs.version }}-checksums.txt
+        files: checksums-${{ steps.extract_version.outputs.version }}.txt
 
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -11,9 +11,12 @@
    - Windows x64 (zip形式)
    - macOS x64/ARM64 (zip形式)
    - Linux x64/ARM64 (zip形式)
-3. **リリース作成**: GitHubリリースが自動作成（softprops/action-gh-release@v2使用）
-4. **checksums.txt生成**: 全アセットのSHA256ハッシュを自動生成
-5. **Scoop更新**: scoop-bucketリポジトリで6時間ごとに自動チェック
+3. **複数バイナリのビルド**: 
+   - **redmine-cli**: メインのRedmineCLIアプリケーション
+   - **redmine-board**: Board拡張機能（フォームベース認証対応）
+4. **リリース作成**: GitHubリリースが自動作成（softprops/action-gh-release@v2使用）
+5. **checksums.txt生成**: 全アセット（redmine-cli、redmine-board両方）のSHA256ハッシュを自動生成
+6. **Scoop更新**: scoop-bucketリポジトリで6時間ごとに自動チェック
 
 ### バージョン表示ルール
 
@@ -35,8 +38,11 @@ VERSION=v0.9.0
 # テストの実行
 dotnet test
 
-# Native AOTビルドの確認
-dotnet publish -c Release -r win-x64 -p:PublishAot=true
+# Native AOTビルドの確認（メインアプリケーション）
+dotnet publish RedmineCLI/RedmineCLI.csproj -c Release -r win-x64 -p:PublishAot=true
+
+# Native AOTビルドの確認（Board拡張）
+dotnet publish RedmineCLI.Extension.Board/RedmineCLI.Extension.Board.csproj -c Release -r win-x64 -p:PublishAot=true
 ```
 
 ### 2. タグの作成とプッシュ
@@ -54,8 +60,10 @@ git push origin $VERSION
 GitHub Actionsによって以下が自動的に実行されます：
 
 1. 全プラットフォーム向けのバイナリビルド（zip形式）
+   - `redmine-cli-{version}-{platform}.zip`: メインアプリケーション
+   - `redmine-board-{version}-{platform}.zip`: Board拡張機能
 2. リリースの作成（現在は即座に公開）
-3. checksums.txtの生成とアップロード（Scoop自動更新に必要）
+3. checksums-{version}.txtの生成とアップロード（全バイナリのSHA256ハッシュを含む）
 
 ### 4. リリースノートの確認と編集
 
@@ -86,8 +94,9 @@ GitHub Actionsによって以下が自動的に実行されます：
    ```yaml
    uses: robinraju/release-downloader@v1.11
    ```
-   - 全アセットのSHA256ハッシュを含む
+   - 全アセット（redmine-cli、redmine-board）のSHA256ハッシュを含む
    - Scoop等のパッケージマネージャーで利用
+   - ファイル名: `checksums-{version}.txt`
 
 4. **バージョンの動的設定**
    ```yaml


### PR DESCRIPTION
## 概要
GitHub Actionsのリリースワークフローを更新して、`redmine-board`拡張機能も自動的にビルド・配布できるようにしました。

## 変更内容

### .github/workflows/release.yml
- ✨ redmine-boardのビルドステップを追加
- 📦 各プラットフォーム用に2つのバイナリ（redmine-cli, redmine-board）を生成
- 📝 リリースノートにredmine-boardの説明と使用例を追加
- 🔐 チェックサム生成を更新して全バイナリのSHA256ハッシュを含むように変更

### docs/RELEASE.md
- 📚 複数バイナリのビルドとリリースについて文書化
- 🔧 redmine-boardのビルド確認手順を追加

## 配布形式
各リリースには以下のファイルが含まれます：
- `redmine-cli-{version}-{platform}.zip`: メインアプリケーション
- `redmine-board-{version}-{platform}.zip`: Board拡張機能（フォームベース認証対応）
- `checksums-{version}.txt`: 全バイナリのSHA256ハッシュ

## テスト計画
- [ ] GitHub Actionsワークフローが正常に実行されることを確認
- [ ] 次回のリリースタグで両方のバイナリが正しくビルドされることを確認
- [ ] 生成されたチェックサムファイルに全バイナリが含まれることを確認