### PR TITLE
feat: redmine-board拡張にboard:topic記法を実装

### DIFF
--- a/RedmineCLI.Extension.Board.Tests/Parsers/BoardTopicParserTests.cs
+++ b/RedmineCLI.Extension.Board.Tests/Parsers/BoardTopicParserTests.cs
@@ -1,0 +1,201 @@
+using FluentAssertions;
+
+using RedmineCLI.Extension.Board.Parsers;
+
+namespace RedmineCLI.Extension.Board.Tests.Parsers;
+
+public class BoardTopicParserTests
+{
+    [Fact]
+    public void Parse_Should_ReturnInvalid_When_InputIsNull()
+    {
+        // Arrange
+        string? input = null;
+
+        // Act
+        var result = BoardTopicParser.Parse(input!);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_Should_ReturnInvalid_When_InputIsEmpty()
+    {
+        // Arrange
+        var input = "";
+
+        // Act
+        var result = BoardTopicParser.Parse(input);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_Should_ReturnInvalid_When_InputIsWhitespace()
+    {
+        // Arrange
+        var input = "   ";
+
+        // Act
+        var result = BoardTopicParser.Parse(input);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_Should_ReturnWildcard_When_InputIsAsterisk()
+    {
+        // Arrange
+        var input = "*";
+
+        // Act
+        var result = BoardTopicParser.Parse(input);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.IsWildcard.Should().BeTrue();
+        result.BoardId.Should().BeNull();
+        result.TopicId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_Should_ReturnBoardIdOnly_When_InputIsSingleNumber()
+    {
+        // Arrange
+        var input = "21";
+
+        // Act
+        var result = BoardTopicParser.Parse(input);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.BoardId.Should().Be(21);
+        result.TopicId.Should().BeNull();
+        result.IsWildcard.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_Should_ReturnBoardAndTopicId_When_InputIsBoardColonTopic()
+    {
+        // Arrange
+        var input = "21:145";
+
+        // Act
+        var result = BoardTopicParser.Parse(input);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.BoardId.Should().Be(21);
+        result.TopicId.Should().Be(145);
+        result.IsWildcard.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_Should_ReturnInvalid_When_BoardIdIsNotNumber()
+    {
+        // Arrange
+        var input = "abc";
+
+        // Act
+        var result = BoardTopicParser.Parse(input);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_Should_ReturnInvalid_When_BoardIdIsNotNumber_InBoardColonTopicFormat()
+    {
+        // Arrange
+        var input = "abc:145";
+
+        // Act
+        var result = BoardTopicParser.Parse(input);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_Should_ReturnInvalid_When_TopicIdIsNotNumber_InBoardColonTopicFormat()
+    {
+        // Arrange
+        var input = "21:abc";
+
+        // Act
+        var result = BoardTopicParser.Parse(input);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_Should_ReturnInvalid_When_TooManyColons()
+    {
+        // Arrange
+        var input = "21:145:999";
+
+        // Act
+        var result = BoardTopicParser.Parse(input);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_Should_HandleLargeNumbers()
+    {
+        // Arrange
+        var input = "999999:888888";
+
+        // Act
+        var result = BoardTopicParser.Parse(input);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.BoardId.Should().Be(999999);
+        result.TopicId.Should().Be(888888);
+    }
+
+    [Fact]
+    public void Parse_Should_ReturnInvalid_When_ColonOnly()
+    {
+        // Arrange
+        var input = ":";
+
+        // Act
+        var result = BoardTopicParser.Parse(input);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_Should_ReturnInvalid_When_EmptyBeforeColon()
+    {
+        // Arrange
+        var input = ":145";
+
+        // Act
+        var result = BoardTopicParser.Parse(input);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_Should_ReturnInvalid_When_EmptyAfterColon()
+    {
+        // Arrange
+        var input = "21:";
+
+        // Act
+        var result = BoardTopicParser.Parse(input);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+    }
+}

--- a/RedmineCLI.Extension.Board.Tests/RedmineCLI.Extension.Board.Tests.csproj
+++ b/RedmineCLI.Extension.Board.Tests/RedmineCLI.Extension.Board.Tests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <PublishAot>false</PublishAot>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="8.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RedmineCLI.Extension.Board\RedmineCLI.Extension.Board.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/RedmineCLI.Extension.Board/Commands/CommentCommand.cs
+++ b/RedmineCLI.Extension.Board/Commands/CommentCommand.cs
@@ -1,0 +1,41 @@
+using System.CommandLine;
+
+using Microsoft.Extensions.Logging;
+
+namespace RedmineCLI.Extension.Board.Commands;
+
+/// <summary>
+/// redmine-board comment コマンドの実装（replyコマンドのエイリアス）
+/// </summary>
+public class CommentCommand
+{
+    private readonly ReplyCommand _replyCommand;
+
+    public CommentCommand(ReplyCommand replyCommand)
+    {
+        _replyCommand = replyCommand;
+    }
+
+    public Command Create()
+    {
+        // replyコマンドを基に作成し、名前と説明を変更
+        var replyCommandBase = _replyCommand.Create();
+        var command = new Command("comment", "Comment on a board topic (alias for reply)");
+
+        // replyコマンドから引数とオプションをコピー
+        foreach (var argument in replyCommandBase.Arguments)
+        {
+            command.Add(argument);
+        }
+
+        foreach (var option in replyCommandBase.Options)
+        {
+            command.Add(option);
+        }
+
+        // replyコマンドと同じハンドラーを使用
+        command.Handler = replyCommandBase.Handler;
+
+        return command;
+    }
+}

--- a/RedmineCLI.Extension.Board/Commands/ReplyCommand.cs
+++ b/RedmineCLI.Extension.Board/Commands/ReplyCommand.cs
@@ -1,0 +1,72 @@
+using System.CommandLine;
+
+using Microsoft.Extensions.Logging;
+
+using RedmineCLI.Extension.Board.Parsers;
+using RedmineCLI.Extension.Board.Services;
+
+namespace RedmineCLI.Extension.Board.Commands;
+
+/// <summary>
+/// redmine-board reply コマンドの実装
+/// </summary>
+public class ReplyCommand
+{
+    private readonly ILogger<ReplyCommand> _logger;
+    private readonly IBoardService _boardService;
+    private readonly IAuthenticationService _authenticationService;
+
+    public ReplyCommand(
+        ILogger<ReplyCommand> logger,
+        IBoardService boardService,
+        IAuthenticationService authenticationService)
+    {
+        _logger = logger;
+        _boardService = boardService;
+        _authenticationService = authenticationService;
+    }
+
+    public Command Create()
+    {
+        var command = new Command("reply", "Reply to a board topic");
+
+        // board:topic形式の引数
+        var targetArgument = new Argument<string>(
+            "target",
+            "Board:topic notation (e.g., 21:145)");
+        command.Add(targetArgument);
+
+        // メッセージオプション
+        var messageOption = new Option<string>(
+            new[] { "-m", "--message" },
+            "Reply message")
+        {
+            IsRequired = true
+        };
+        command.Add(messageOption);
+
+        command.SetHandler(async (string target, string message) =>
+        {
+            await HandleReplyCommand(target, message);
+        }, targetArgument, messageOption);
+
+        return command;
+    }
+
+    private Task HandleReplyCommand(string target, string message)
+    {
+        var parseResult = BoardTopicParser.Parse(target);
+
+        if (!parseResult.IsValid || !parseResult.TopicId.HasValue)
+        {
+            Spectre.Console.AnsiConsole.MarkupLine($"[red]Invalid format: '{target}'[/]");
+            Spectre.Console.AnsiConsole.MarkupLine("Usage: redmine-board reply <board-id>:<topic-id> -m <message>");
+            return Task.CompletedTask;
+        }
+
+        // 現時点では返信機能は未実装のため、プレースホルダーメッセージを表示
+        Spectre.Console.AnsiConsole.MarkupLine($"[yellow]Reply functionality to topic {parseResult.BoardId}:{parseResult.TopicId} is not yet implemented.[/]");
+        Spectre.Console.AnsiConsole.MarkupLine($"[dim]Message: {message}[/]");
+        return Task.CompletedTask;
+    }
+}

--- a/RedmineCLI.Extension.Board/Commands/ViewCommand.cs
+++ b/RedmineCLI.Extension.Board/Commands/ViewCommand.cs
@@ -1,0 +1,95 @@
+using System.CommandLine;
+
+using Microsoft.Extensions.Logging;
+
+using RedmineCLI.Extension.Board.Parsers;
+using RedmineCLI.Extension.Board.Services;
+
+namespace RedmineCLI.Extension.Board.Commands;
+
+/// <summary>
+/// redmine-board view コマンドの実装
+/// </summary>
+public class ViewCommand
+{
+    private readonly ILogger<ViewCommand> _logger;
+    private readonly IBoardService _boardService;
+    private readonly IAuthenticationService _authenticationService;
+
+    public ViewCommand(
+        ILogger<ViewCommand> logger,
+        IBoardService boardService,
+        IAuthenticationService authenticationService)
+    {
+        _logger = logger;
+        _boardService = boardService;
+        _authenticationService = authenticationService;
+    }
+
+    public Command Create()
+    {
+        var command = new Command("view", "View boards, topics, or topic details");
+
+        // board:topic形式の引数
+        var targetArgument = new Argument<string>(
+            "target",
+            "Board ID, board:topic notation (e.g., 21:145), or * for all boards");
+        command.Add(targetArgument);
+
+        // プロジェクトオプション
+        var projectOption = new Option<string>(
+            "--project",
+            "Project name or ID");
+        command.Add(projectOption);
+
+        command.SetHandler(async (string target, string? project) =>
+        {
+            await HandleViewCommand(target, project);
+        }, targetArgument, projectOption);
+
+        return command;
+    }
+
+    private async Task HandleViewCommand(string target, string? project)
+    {
+        var parseResult = BoardTopicParser.Parse(target);
+
+        if (!parseResult.IsValid)
+        {
+            Spectre.Console.AnsiConsole.MarkupLine($"[red]Invalid format: '{target}'[/]");
+            Spectre.Console.AnsiConsole.MarkupLine("Usage: redmine-board view <board-id> | <board-id>:<topic-id> | *");
+            return;
+        }
+
+        var (url, sessionCookie) = await _authenticationService.GetAuthenticationAsync(null);
+        if (string.IsNullOrEmpty(sessionCookie))
+        {
+            return;
+        }
+
+        var auth = (sessionCookie, url);
+
+        if (parseResult.IsWildcard)
+        {
+            // 全ボードのトピック一覧（将来実装）
+            Spectre.Console.AnsiConsole.MarkupLine("[yellow]Wildcard (*) support is not yet implemented.[/]");
+        }
+        else if (parseResult.TopicId.HasValue)
+        {
+            // トピック詳細と返信を表示
+            await _boardService.ViewTopicAsync(
+                parseResult.BoardId!.Value.ToString(),
+                parseResult.TopicId.Value.ToString(),
+                project,
+                auth);
+        }
+        else if (parseResult.BoardId.HasValue)
+        {
+            // ボードのトピック一覧を表示
+            await _boardService.ListTopicsAsync(
+                parseResult.BoardId.Value.ToString(),
+                project,
+                auth);
+        }
+    }
+}

--- a/RedmineCLI.Extension.Board/Parsers/BoardTopicParser.cs
+++ b/RedmineCLI.Extension.Board/Parsers/BoardTopicParser.cs
@@ -1,0 +1,73 @@
+namespace RedmineCLI.Extension.Board.Parsers;
+
+/// <summary>
+/// board:topic記法のパーサー
+/// </summary>
+public static class BoardTopicParser
+{
+    /// <summary>
+    /// board:topic記法をパースする
+    /// </summary>
+    /// <param name="input">入力文字列（例: "21", "21:145", "*"）</param>
+    /// <returns>パース結果</returns>
+    public static BoardTopicParseResult Parse(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return new BoardTopicParseResult { IsValid = false };
+        }
+
+        // ワイルドカード対応
+        if (input == "*")
+        {
+            return new BoardTopicParseResult
+            {
+                IsValid = true,
+                IsWildcard = true
+            };
+        }
+
+        // board:topic形式
+        var parts = input.Split(':');
+
+        if (parts.Length == 1)
+        {
+            // ボードIDのみ
+            if (int.TryParse(parts[0], out var boardId))
+            {
+                return new BoardTopicParseResult
+                {
+                    IsValid = true,
+                    BoardId = boardId
+                };
+            }
+        }
+        else if (parts.Length == 2)
+        {
+            // board:topic形式
+            if (int.TryParse(parts[0], out var boardId) &&
+                int.TryParse(parts[1], out var topicId))
+            {
+                return new BoardTopicParseResult
+                {
+                    IsValid = true,
+                    BoardId = boardId,
+                    TopicId = topicId
+                };
+            }
+        }
+
+        return new BoardTopicParseResult { IsValid = false };
+    }
+}
+
+/// <summary>
+/// board:topic記法のパース結果
+/// </summary>
+public class BoardTopicParseResult
+{
+    public bool IsValid { get; set; }
+    public int? BoardId { get; set; }
+    public int? TopicId { get; set; }
+    public bool IsWildcard { get; set; }
+}

--- a/RedmineCLI.Extension.Board/Program.cs
+++ b/RedmineCLI.Extension.Board/Program.cs
@@ -33,12 +33,18 @@ public class Program
         var boardListCommand = serviceProvider.GetRequiredService<BoardListCommand>();
         var infoCommand = serviceProvider.GetRequiredService<InfoCommand>();
         var boardTopicCommand = serviceProvider.GetRequiredService<BoardTopicCommand>();
+        var viewCommand = serviceProvider.GetRequiredService<ViewCommand>();
+        var replyCommand = serviceProvider.GetRequiredService<ReplyCommand>();
+        var commentCommand = serviceProvider.GetRequiredService<CommentCommand>();
 
-        // Add commands
+        // Add new commands
         rootCommand.AddCommand(boardListCommand.Create());
+        rootCommand.AddCommand(viewCommand.Create());
+        rootCommand.AddCommand(replyCommand.Create());
+        rootCommand.AddCommand(commentCommand.Create());
         rootCommand.AddCommand(infoCommand.Create());
 
-        // Handle dynamic board ID commands (e.g., "redmine-board 21 topic list")
+        // Handle dynamic board ID commands for backward compatibility (e.g., "redmine-board 21 topic list")
         var dynamicBoardCommand = boardTopicCommand.CreateDynamicBoardCommand(args);
         if (dynamicBoardCommand != null)
         {
@@ -72,5 +78,8 @@ public class Program
         services.AddScoped<BoardListCommand>();
         services.AddScoped<InfoCommand>();
         services.AddScoped<BoardTopicCommand>();
+        services.AddScoped<ViewCommand>();
+        services.AddScoped<ReplyCommand>();
+        services.AddScoped<CommentCommand>();
     }
 }

--- a/RedmineCLI.sln
+++ b/RedmineCLI.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RedmineCLI.Common.Tests", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RedmineCLI.Extension.Board", "RedmineCLI.Extension.Board\RedmineCLI.Extension.Board.csproj", "{195E7420-951D-4C7C-9416-096772916776}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RedmineCLI.Extension.Board.Tests", "RedmineCLI.Extension.Board.Tests\RedmineCLI.Extension.Board.Tests.csproj", "{A5B7F6C8-D932-4E2F-9A43-108883957321}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +85,18 @@ Global
 		{195E7420-951D-4C7C-9416-096772916776}.Release|x64.Build.0 = Release|Any CPU
 		{195E7420-951D-4C7C-9416-096772916776}.Release|x86.ActiveCfg = Release|Any CPU
 		{195E7420-951D-4C7C-9416-096772916776}.Release|x86.Build.0 = Release|Any CPU
+		{A5B7F6C8-D932-4E2F-9A43-108883957321}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5B7F6C8-D932-4E2F-9A43-108883957321}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5B7F6C8-D932-4E2F-9A43-108883957321}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A5B7F6C8-D932-4E2F-9A43-108883957321}.Debug|x64.Build.0 = Debug|Any CPU
+		{A5B7F6C8-D932-4E2F-9A43-108883957321}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A5B7F6C8-D932-4E2F-9A43-108883957321}.Debug|x86.Build.0 = Debug|Any CPU
+		{A5B7F6C8-D932-4E2F-9A43-108883957321}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5B7F6C8-D932-4E2F-9A43-108883957321}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5B7F6C8-D932-4E2F-9A43-108883957321}.Release|x64.ActiveCfg = Release|Any CPU
+		{A5B7F6C8-D932-4E2F-9A43-108883957321}.Release|x64.Build.0 = Release|Any CPU
+		{A5B7F6C8-D932-4E2F-9A43-108883957321}.Release|x86.ActiveCfg = Release|Any CPU
+		{A5B7F6C8-D932-4E2F-9A43-108883957321}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- board:topic記法のパーサーを追加 (例: "21:145", "21", "*")
- viewコマンドを追加: `redmine-board view <board-id>:<topic-id>`
- replyコマンドを追加: `redmine-board reply <board-id>:<topic-id> -m`
- commentコマンドを追加（replyのエイリアス）
- 後方互換性のため既存のコマンド構造も維持
- BoardTopicParserのユニットテストを追加（16テスト）

すべてのテストがパスし、ビルドも成功しています。