### PR TITLE
fix: System.CommandLineのローカライゼーション問題を修正 (#94)

### DIFF
--- a/RedmineCLI/Program.cs
+++ b/RedmineCLI/Program.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.Globalization;
 using System.IO.Abstractions;
 using System.Linq;
 
@@ -22,6 +23,10 @@ public class Program
 {
     public static async Task<int> Main(string[] args)
     {
+        // Force English locale for System.CommandLine messages
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+
         // Create service collection and configure DI
         var services = new ServiceCollection();
         ConfigureServices(services);


### PR DESCRIPTION
## 概要
System.CommandLineライブラリのエラーメッセージが日本語で表示される問題を修正しました。

## 問題
- System.CommandLineライブラリが自動的にシステムのロケール設定を使用してエラーメッセージを日本語で表示していた
- コマンドライン引数のエラーや無効なオプションなどのメッセージが日本語で表示されていた
- 国際的な開発環境やエラー報告において言語の違いが問題となっていた

## 解決方法
- `Program.cs`の`Main`メソッドの最初で`CultureInfo.CurrentCulture`と`CultureInfo.CurrentUICulture`を`InvariantCulture`に設定
- これによりSystem.CommandLineのすべてのメッセージが英語で表示されるようになった

## 変更内容
- `RedmineCLI/Program.cs`に以下を追加：
  ```csharp
  // Force English locale for System.CommandLine messages
  CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
  CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
  ```
- 必要な`using System.Globalization;`文を追加

## テスト
- コマンドライン引数エラー時のメッセージが英語で表示されることを確認
- 無効なオプション指定時のメッセージが英語で表示されることを確認

Fixes #94