### PR TITLE
feat: redmine version listコマンドを追加

### DIFF
--- a/RedmineCLI.Tests/Commands/VersionCommandTests.cs
+++ b/RedmineCLI.Tests/Commands/VersionCommandTests.cs
@@ -1,0 +1,120 @@
+using System.CommandLine;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging;
+
+using NSubstitute;
+
+using RedmineCLI.Commands;
+using RedmineCLI.Formatters;
+using RedmineCLI.Models;
+using RedmineCLI.Services;
+
+using Xunit;
+
+namespace RedmineCLI.Tests.Commands;
+
+public class VersionCommandTests
+{
+    private readonly IRedmineService _redmineService;
+    private readonly IConfigService _configService;
+    private readonly ITableFormatter _tableFormatter;
+    private readonly IJsonFormatter _jsonFormatter;
+    private readonly ILogger<VersionCommand> _logger;
+
+    public VersionCommandTests()
+    {
+        _redmineService = Substitute.For<IRedmineService>();
+        _configService = Substitute.For<IConfigService>();
+        _tableFormatter = Substitute.For<ITableFormatter>();
+        _jsonFormatter = Substitute.For<IJsonFormatter>();
+        _logger = Substitute.For<ILogger<VersionCommand>>();
+
+        var config = new Config
+        {
+            CurrentProfile = "default",
+            Profiles = new Dictionary<string, Profile>(),
+            Preferences = new Preferences()
+        };
+        _configService.LoadConfigAsync().Returns(Task.FromResult(config));
+    }
+
+    [Fact]
+    public void Command_Should_HaveLsAlias()
+    {
+        // Arrange & Act
+        var command = VersionCommand.Create(_redmineService, _configService, _tableFormatter, _jsonFormatter, _logger);
+        var listCommand = command.Subcommands.First(c => c.Name == "list");
+
+        // Assert
+        listCommand.Aliases.Should().Contain("ls");
+    }
+
+    [Fact]
+    public async Task List_Should_ReturnVersions_When_ProjectIsSpecified()
+    {
+        // Arrange
+        var versions = new List<TargetVersion>
+        {
+            new TargetVersion { Id = 1, Name = "v1.0.0", Status = "closed" },
+            new TargetVersion { Id = 2, Name = "v1.1.0", Status = "open" },
+            new TargetVersion { Id = 3, Name = "v2.0.0", Status = "locked" }
+        };
+
+        _redmineService.GetVersionsAsync("my-project", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(versions));
+
+        var command = VersionCommand.Create(_redmineService, _configService, _tableFormatter, _jsonFormatter, _logger);
+        var parseResult = command.Parse("list --project my-project");
+
+        // Act
+        var result = await parseResult.InvokeAsync();
+
+        // Assert
+        result.Should().Be(0);
+        await _redmineService.Received(1).GetVersionsAsync("my-project", Arg.Any<CancellationToken>());
+        _tableFormatter.Received(1).FormatVersions(versions);
+    }
+
+    [Fact]
+    public async Task List_Should_FormatAsJson_When_JsonOptionIsSet()
+    {
+        // Arrange
+        var versions = new List<TargetVersion>
+        {
+            new TargetVersion { Id = 1, Name = "v1.0.0", Status = "open" }
+        };
+
+        _redmineService.GetVersionsAsync("my-project", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(versions));
+
+        var command = VersionCommand.Create(_redmineService, _configService, _tableFormatter, _jsonFormatter, _logger);
+        var parseResult = command.Parse("list --project my-project --json");
+
+        // Act
+        var result = await parseResult.InvokeAsync();
+
+        // Assert
+        result.Should().Be(0);
+        await _redmineService.Received(1).GetVersionsAsync("my-project", Arg.Any<CancellationToken>());
+        _jsonFormatter.Received(1).FormatVersions(versions);
+        _tableFormatter.DidNotReceive().FormatVersions(Arg.Any<List<TargetVersion>>());
+    }
+
+    [Fact]
+    public async Task List_Should_ReturnError_When_ProjectIsNotSpecified()
+    {
+        // Arrange
+        var command = VersionCommand.Create(_redmineService, _configService, _tableFormatter, _jsonFormatter, _logger);
+        var parseResult = command.Parse("list");
+
+        // Act
+        var result = await parseResult.InvokeAsync();
+
+        // Assert
+        // System.CommandLine returns non-zero for missing required options
+        result.Should().NotBe(0);
+        await _redmineService.DidNotReceive().GetVersionsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/RedmineCLI/Commands/VersionCommand.cs
+++ b/RedmineCLI/Commands/VersionCommand.cs
@@ -1,0 +1,97 @@
+using System.CommandLine;
+
+using Microsoft.Extensions.Logging;
+
+using RedmineCLI.Exceptions;
+using RedmineCLI.Formatters;
+using RedmineCLI.Services;
+
+using Spectre.Console;
+
+namespace RedmineCLI.Commands;
+
+public class VersionCommand
+{
+    private readonly IRedmineService _redmineService;
+    private readonly IConfigService _configService;
+    private readonly ITableFormatter _tableFormatter;
+    private readonly IJsonFormatter _jsonFormatter;
+    private readonly ILogger<VersionCommand> _logger;
+
+    public VersionCommand(
+        IRedmineService redmineService,
+        IConfigService configService,
+        ITableFormatter tableFormatter,
+        IJsonFormatter jsonFormatter,
+        ILogger<VersionCommand> logger)
+    {
+        _redmineService = redmineService;
+        _configService = configService;
+        _tableFormatter = tableFormatter;
+        _jsonFormatter = jsonFormatter;
+        _logger = logger;
+    }
+
+    public static Command Create(
+        IRedmineService redmineService,
+        IConfigService configService,
+        ITableFormatter tableFormatter,
+        IJsonFormatter jsonFormatter,
+        ILogger<VersionCommand> logger)
+    {
+        var command = new Command("version", "Manage project versions");
+        var versionCommand = new VersionCommand(redmineService, configService, tableFormatter, jsonFormatter, logger);
+
+        var listCommand = new Command("list", "List project versions");
+        listCommand.Aliases.Add("ls");
+
+        var projectOption = new Option<string>("--project", "-p") { Description = "Project identifier (required)", Required = true };
+        var jsonOption = new Option<bool>("--json") { Description = "Output in JSON format" };
+
+        listCommand.Add(projectOption);
+        listCommand.Add(jsonOption);
+
+        listCommand.SetAction(async (parseResult) =>
+        {
+            var project = parseResult.GetValue(projectOption)!;
+            var json = parseResult.GetValue(jsonOption);
+            Environment.ExitCode = await versionCommand.ListVersionsAsync(project, json);
+        });
+
+        command.Add(listCommand);
+        return command;
+    }
+
+    private async Task<int> ListVersionsAsync(string project, bool json)
+    {
+        try
+        {
+            _logger.LogDebug("Listing versions for project: {Project}", project);
+
+            var versions = await _redmineService.GetVersionsAsync(project);
+
+            if (json)
+            {
+                _jsonFormatter.FormatVersions(versions);
+            }
+            else
+            {
+                _tableFormatter.FormatVersions(versions);
+            }
+
+            return 0;
+        }
+        catch (RedmineApiException ex)
+        {
+            _logger.LogError(ex, "API error while listing versions");
+            AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message}");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error while listing versions");
+            AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message}");
+            return 1;
+        }
+    }
+}

--- a/RedmineCLI/Formatters/IJsonFormatter.cs
+++ b/RedmineCLI/Formatters/IJsonFormatter.cs
@@ -13,4 +13,5 @@ public interface IJsonFormatter
     void FormatProjects(List<Project> projects);
     void FormatIssueStatuses(List<IssueStatus> statuses);
     void FormatPriorities(List<Priority> priorities);
+    void FormatVersions(List<TargetVersion> versions);
 }

--- a/RedmineCLI/Formatters/ITableFormatter.cs
+++ b/RedmineCLI/Formatters/ITableFormatter.cs
@@ -16,4 +16,5 @@ public interface ITableFormatter
     void FormatProjects(List<Project> projects);
     void FormatIssueStatuses(List<IssueStatus> statuses);
     void FormatPriorities(List<Priority> priorities);
+    void FormatVersions(List<TargetVersion> versions);
 }

--- a/RedmineCLI/Formatters/JsonFormatter.cs
+++ b/RedmineCLI/Formatters/JsonFormatter.cs
@@ -82,4 +82,10 @@ public class JsonFormatter : IJsonFormatter
         var json = JsonSerializer.Serialize(priorities, RedmineJsonContext.Default.ListPriority);
         AnsiConsole.WriteLine(json);
     }
+
+    public void FormatVersions(List<TargetVersion> versions)
+    {
+        var json = JsonSerializer.Serialize(versions, RedmineJsonContext.Default.ListTargetVersion);
+        AnsiConsole.WriteLine(json);
+    }
 }

--- a/RedmineCLI/Formatters/TableFormatter.cs
+++ b/RedmineCLI/Formatters/TableFormatter.cs
@@ -603,4 +603,23 @@ public class TableFormatter : ITableFormatter
 
         AnsiConsole.Write(table);
     }
+
+    public void FormatVersions(List<TargetVersion> versions)
+    {
+        var table = new Table();
+        table.AddColumn("ID");
+        table.AddColumn("NAME");
+        table.AddColumn("STATUS");
+
+        foreach (var version in versions)
+        {
+            table.AddRow(
+                version.Id.ToString(),
+                Markup.Escape(version.Name),
+                Markup.Escape(version.Status ?? "")
+            );
+        }
+
+        AnsiConsole.Write(table);
+    }
 }

--- a/RedmineCLI/Program.cs
+++ b/RedmineCLI/Program.cs
@@ -57,6 +57,7 @@ public class Program
         var projectLogger = serviceProvider.GetRequiredService<ILogger<ProjectCommand>>();
         var statusLogger = serviceProvider.GetRequiredService<ILogger<StatusCommand>>();
         var priorityLogger = serviceProvider.GetRequiredService<ILogger<PriorityCommand>>();
+        var versionLogger = serviceProvider.GetRequiredService<ILogger<VersionCommand>>();
         var mcpLogger = serviceProvider.GetRequiredService<ILogger<McpCommand>>();
         var mcpServerLogger = serviceProvider.GetRequiredService<ILogger<Services.Mcp.McpServer>>();
 
@@ -64,6 +65,7 @@ public class Program
         var projectCommand = ProjectCommand.Create(redmineService, configService, tableFormatter, jsonFormatter, projectLogger);
         var statusCommand = StatusCommand.Create(redmineService, configService, tableFormatter, jsonFormatter, statusLogger);
         var priorityCommand = PriorityCommand.Create(redmineService, configService, tableFormatter, jsonFormatter, priorityLogger);
+        var versionCommand = VersionCommand.Create(redmineService, configService, tableFormatter, jsonFormatter, versionLogger);
         var mcpCommand = McpCommand.Create(redmineService, mcpLogger, mcpServerLogger);
 
         rootCommand.Add(authCommand);
@@ -74,6 +76,7 @@ public class Program
         rootCommand.Add(projectCommand);
         rootCommand.Add(statusCommand);
         rootCommand.Add(priorityCommand);
+        rootCommand.Add(versionCommand);
         rootCommand.Add(mcpCommand);
 
         // Add llms command after all other commands are added so it can access them


### PR DESCRIPTION
## Summary

- プロジェクトのバージョン一覧を表示する `redmine version list --project <id>` コマンドを追加
- `ls` エイリアス、`--json` オプション対応
- 既存の `GetVersionsAsync` API・サービス層を再利用

## 使用例

```bash
redmine version list --project my-project
redmine version ls --project my-project --json
```

## Test plan

- [x] 全731テストパス
- [x] 実APIでの動作確認済み
- [x] AOTビルド成功